### PR TITLE
fix(security): harden release and OAuth error handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,23 +22,23 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Select latest stable Xcode
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
         with:
           xcode-version: latest-stable
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1
         with:
           ruby-version: .ruby-version
           bundler-cache: true
 
       - name: Restore SwiftPM build cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .build
           key: ${{ runner.os }}-swiftpm-${{ github.workflow }}-${{ hashFiles('Package.swift', 'Package.resolved') }}
@@ -46,7 +46,7 @@ jobs:
             ${{ runner.os }}-swiftpm-${{ github.workflow }}-
 
       - name: Restore CocoaPods cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             Example/Pods
@@ -85,24 +85,24 @@ jobs:
           permission-issues: write
           permission-pull-requests: write
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           token: ${{ steps.release-bot.outputs.token }}
 
       - name: Select latest stable Xcode
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
         with:
           xcode-version: latest-stable
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1
         with:
           ruby-version: .ruby-version
           bundler-cache: true
 
       - name: Restore SwiftPM build cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .build
           key: ${{ runner.os }}-swiftpm-${{ github.workflow }}-${{ hashFiles('Package.swift', 'Package.resolved') }}
@@ -110,11 +110,9 @@ jobs:
             ${{ runner.os }}-swiftpm-${{ github.workflow }}-
 
       - name: Restore CocoaPods cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
-          path: |
-            Example/Pods
-            ~/Library/Caches/CocoaPods
+          path: ~/Library/Caches/CocoaPods
           key: ${{ runner.os }}-cocoapods-${{ github.workflow }}-${{ hashFiles('Example/Podfile.lock', 'PutioSDK.podspec', 'podspec_helper.rb') }}
           restore-keys: |
             ${{ runner.os }}-cocoapods-${{ github.workflow }}-
@@ -123,15 +121,15 @@ jobs:
         run: make bootstrap
 
       - name: Release SDK
-        uses: cycjimmy/semantic-release-action@v6
+        uses: cycjimmy/semantic-release-action@b12c8f6015dc215fe37bc154d4ad456dd3833c90 # v6.0.0
         with:
           extra_plugins: |
-            @semantic-release/commit-analyzer
-            @semantic-release/release-notes-generator
-            @semantic-release/exec
-            @semantic-release/github
-            @semantic-release/git
-            conventional-changelog-conventionalcommits
+            @semantic-release/commit-analyzer@13.0.1
+            @semantic-release/release-notes-generator@14.1.1
+            @semantic-release/exec@7.1.0
+            @semantic-release/github@12.0.8
+            @semantic-release/git@10.0.1
+            conventional-changelog-conventionalcommits@9.3.1
         env:
           GITHUB_TOKEN: ${{ steps.release-bot.outputs.token }}
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@
 - CI and release automation run from `main`
 - The release workflow uses semantic-release after `make verify` passes on `main`
 - GitHub release writes use `putio-release-bot`; CocoaPods publishing additionally needs `COCOAPODS_TRUNK_TOKEN` in the protected `release` Environment
+- Release jobs cache CocoaPods downloads only and regenerate generated `Example/Pods`
 - Verify example workspace installation when auth-flow or package-install surface changes
 - Repo verification should build the Swift package and the `PutioSDK` CocoaPods scheme from the example workspace
 - `make verify` prefers an Xcode-advertised iPhone simulator destination on iOS `26.0+` and falls back to the installed `iphonesimulator` SDK when Xcode is not exposing one yet

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,7 @@ make print-simulator-destination
 - Conventional commits drive automated version selection through semantic-release
 - GitHub release writes use `putio-release-bot` through `PUTIO_RELEASE_BOT_APP_ID` and `PUTIO_RELEASE_BOT_PRIVATE_KEY` in the protected `release` Environment
 - CocoaPods publishing additionally needs `COCOAPODS_TRUNK_TOKEN` in the protected `release` Environment
+- Release jobs cache CocoaPods download artifacts only and regenerate generated `Example/Pods`
 
 ## Pull Requests
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - PutioSDK (3.0.0)
+  - PutioSDK (3.1.0)
 
 DEPENDENCIES:
   - PutioSDK (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  PutioSDK: 1184b31099dfd94ef201fcad9e1446e22827f923
+  PutioSDK: 1c35596d70be4b14932593ef898f48112a0a4143
 
 PODFILE CHECKSUM: e929897f16b1021dbb0f00ef39efb79f3674073a
 

--- a/Example/PutioSDK/ViewController.swift
+++ b/Example/PutioSDK/ViewController.swift
@@ -5,6 +5,10 @@ import AuthenticationServices
 class ViewController: UIViewController {
     var api: PutioSDK?
     var session: ASWebAuthenticationSession?
+    var pendingOAuthState: String?
+
+    private let authCallbackScheme = "putioswift"
+    private let authCallbackHost = "auth"
 
     @IBOutlet weak var textField: UITextField!
     @IBOutlet weak var startButton: UIButton!
@@ -31,13 +35,22 @@ class ViewController: UIViewController {
     func startAuthFlow() {
         guard let api = api else { return }
 
-        let scheme = "putioswift"
-        let url = api.getAuthURL(redirectURI: "\(scheme)://auth")
+        let state: String
+        do {
+            state = try PutioSDK.generateOAuthState()
+        } catch {
+            return handleAuthCallbackFailure(error: error)
+        }
 
-        session = ASWebAuthenticationSession(url: url, callbackURLScheme: scheme) { callbackURL, error in
+        pendingOAuthState = state
+        let url = api.getAuthURL(redirectURI: "\(authCallbackScheme)://\(authCallbackHost)", state: state)
+
+        session = ASWebAuthenticationSession(url: url, callbackURLScheme: authCallbackScheme) { [weak self] callbackURL, error in
+            guard let self else { return }
+            self.session = nil
+
             guard error == nil, let callbackURL = callbackURL else {
-                return self.handleAuthCallbackFailure(error: error!)
-
+                return self.handleAuthCallbackFailure(error: error ?? self.makeAuthError("Missing OAuth callback URL"))
             }
 
             // Callback URL: putioswift://auth#access_token={TOKEN}
@@ -49,6 +62,9 @@ class ViewController: UIViewController {
     }
 
     func handleAuthCallbackFailure(error: Error) {
+        pendingOAuthState = nil
+        session = nil
+
         let alertController = UIAlertController(title: "Auth Failure", message: error.localizedDescription, preferredStyle: .alert)
         let closeButton = UIAlertAction(title: "OK", style: .cancel, handler: nil)
         alertController.addAction(closeButton)
@@ -56,17 +72,35 @@ class ViewController: UIViewController {
     }
 
     func handleAuthCallbackSuccess(callbackURL: URL) {
-        var urlComponents = URLComponents()
-        urlComponents.query = callbackURL.fragment
+        defer {
+            pendingOAuthState = nil
+            session = nil
+        }
 
-        guard let tokenFragment = urlComponents.queryItems?.first(where: { $0.name == "access_token" }), let token = tokenFragment.value else {
-            let error = NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "Missing access_token in the callback URL"])
+        guard let api else { return }
+        guard let pendingOAuthState else {
+            return handleAuthCallbackFailure(error: makeAuthError("Missing pending OAuth state"))
+        }
+
+        let token: String
+        do {
+            token = try api.accessToken(
+                fromOAuthCallback: callbackURL,
+                expectedScheme: authCallbackScheme,
+                expectedHost: authCallbackHost,
+                expectedState: pendingOAuthState
+            )
+        } catch {
             return handleAuthCallbackFailure(error: error)
         }
 
         Task {
             await fetchAccountInfo(token: token)
         }
+    }
+
+    func makeAuthError(_ message: String) -> NSError {
+        NSError(domain: "PutioSDKExampleAuth", code: 0, userInfo: [NSLocalizedDescriptionKey: message])
     }
 
     @MainActor

--- a/Example/README.md
+++ b/Example/README.md
@@ -20,6 +20,6 @@ open Example/PutioSDK.xcworkspace
 - run the `PutioSDK_Example` target
 - enter your OAuth client ID
 - complete the `ASWebAuthenticationSession` sign-in flow
-- confirm the app can fetch account info and list files after the callback
+- confirm the app can fetch account info and list files after the state-validated callback
 
 Do not commit personal tokens, client secrets, or test credentials from local smoke checks

--- a/PutioSDK/Classes/Auth/AuthAPI.swift
+++ b/PutioSDK/Classes/Auth/AuthAPI.swift
@@ -1,7 +1,62 @@
 import Foundation
+import Security
+
+public enum PutioOAuthCallbackError: Error, LocalizedError, Equatable {
+    case invalidCallbackURL
+    case invalidState
+    case missingAccessToken
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidCallbackURL:
+            return "The OAuth callback URL did not match the expected app callback."
+        case .invalidState:
+            return "The OAuth callback state did not match the pending sign-in state."
+        case .missingAccessToken:
+            return "The OAuth callback did not include an access token."
+        }
+    }
+}
+
+public enum PutioOAuthStateError: Error, LocalizedError, Equatable {
+    case invalidByteCount
+    case generationFailed(OSStatus)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidByteCount:
+            return "OAuth state byte count must be greater than zero."
+        case .generationFailed:
+            return "The SDK could not generate a secure OAuth state."
+        }
+    }
+}
 
 extension PutioSDK {
-    public func getAuthURL(redirectURI: String, responseType: String = "token", state: String = "") -> URL {
+    public static func generateOAuthState(byteCount: Int = 32) throws -> String {
+        guard byteCount > 0 else {
+            throw PutioOAuthStateError.invalidByteCount
+        }
+
+        var bytes = [UInt8](repeating: 0, count: byteCount)
+        let status = bytes.withUnsafeMutableBytes { buffer -> OSStatus in
+            guard let baseAddress = buffer.baseAddress else {
+                return errSecParam
+            }
+
+            return SecRandomCopyBytes(kSecRandomDefault, byteCount, baseAddress)
+        }
+        guard status == errSecSuccess else {
+            throw PutioOAuthStateError.generationFailed(status)
+        }
+
+        return Data(bytes).base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    public func getAuthURL(redirectURI: String, responseType: String = "token", state: String) -> URL {
         var url = URLComponents(string: "\(self.config.baseURL)/oauth2/authenticate")
 
         url?.queryItems = [
@@ -17,6 +72,42 @@ extension PutioSDK {
         }
 
         return authURL
+    }
+
+    @available(*, deprecated, message: "Generate and pass a high-entropy state value, for example try PutioSDK.generateOAuthState().")
+    public func getAuthURL(redirectURI: String, responseType: String = "token") -> URL {
+        getAuthURL(redirectURI: redirectURI, responseType: responseType, state: "")
+    }
+
+    public func accessToken(
+        fromOAuthCallback callbackURL: URL,
+        expectedScheme: String,
+        expectedHost: String,
+        expectedState: String
+    ) throws -> String {
+        guard
+            callbackURL.scheme?.caseInsensitiveCompare(expectedScheme) == .orderedSame,
+            callbackURL.host?.caseInsensitiveCompare(expectedHost) == .orderedSame
+        else {
+            throw PutioOAuthCallbackError.invalidCallbackURL
+        }
+
+        var urlComponents = URLComponents()
+        urlComponents.query = callbackURL.fragment
+        let queryItems = urlComponents.queryItems ?? []
+
+        guard
+            !expectedState.isEmpty,
+            queryItems.first(where: { $0.name == "state" })?.value == expectedState
+        else {
+            throw PutioOAuthCallbackError.invalidState
+        }
+
+        guard let token = queryItems.first(where: { $0.name == "access_token" })?.value, !token.isEmpty else {
+            throw PutioOAuthCallbackError.missingAccessToken
+        }
+
+        return token
     }
 
     public func getAuthCode() async throws -> PutioAuthCode {

--- a/PutioSDK/Classes/PutioSDKTypes.swift
+++ b/PutioSDK/Classes/PutioSDKTypes.swift
@@ -230,7 +230,7 @@ extension PutioSDKRequestConfig: CustomStringConvertible, CustomDebugStringConve
         }
 
         components.queryItems = queryItems.map { item in
-            sensitiveKey(item.name) ? URLQueryItem(name: item.name, value: "<redacted>") : item
+            sensitiveKey(item.name) ? URLQueryItem(name: "<redacted>", value: "<redacted>") : item
         }
         return components.string ?? url
     }
@@ -238,7 +238,7 @@ extension PutioSDKRequestConfig: CustomStringConvertible, CustomDebugStringConve
     private var redactedHeaders: PutioHTTPHeaders {
         var redacted: PutioHTTPHeaders = [:]
         for (key, value) in headers {
-            redacted[key] = sensitiveKey(key) ? "<redacted>" : value
+            redacted[sensitiveKey(key) ? "<redacted>" : key] = sensitiveKey(key) ? "<redacted>" : value
         }
         return redacted
     }
@@ -257,19 +257,53 @@ extension PutioSDKErrorRequestInformation: CustomStringConvertible, CustomDebugS
 private func redact(_ parameters: PutioRequestParameters) -> PutioRequestParameters {
     var redacted = PutioRequestParameters()
     for (key, value) in parameters {
-        redacted[key] = sensitiveKey(key) ? "<redacted>" : value
+        redacted[sensitiveKey(key) ? "<redacted>" : key] = sensitiveKey(key) ? "<redacted>" : redact(value)
     }
     return redacted
+}
+
+private func redact(_ value: PutioRequestValue) -> PutioRequestValue {
+    switch value {
+    case let .array(values):
+        return .array(values.map(redact))
+    case let .object(parameters):
+        return .object(redact(parameters))
+    case .string, .integer, .double, .bool:
+        return value
+    }
 }
 
 private func sensitiveKey(_ key: String) -> Bool {
     let normalized = key.lowercased()
     return normalized == "authorization" ||
+        normalized == "password" ||
+        normalized == "current_password" ||
+        normalized == "secret" ||
+        normalized == "recovery_codes" ||
         normalized == "token" ||
         normalized == "oauth_token" ||
         normalized == "access_token" ||
         normalized == "client_secret" ||
-        normalized.hasSuffix("_token")
+        normalized.hasSuffix("_token") ||
+        normalized.hasSuffix("_secret") ||
+        normalized.contains("_secret_")
+}
+
+private func redactSensitiveText(_ text: String) -> String {
+    let replacements = [
+        (#"(?i)([?&](?:[^=\s&#"']*token|[^=\s&#"']*secret|password|current_password|recovery_codes)=)[^\s&#"']+"#, "$1<redacted>"),
+        (#"(?i)((?:^|[\s,])(?:[A-Za-z0-9_]*token|[A-Za-z0-9_]*secret|password|current_password|recovery_codes)=)[^\s,]+"#, "$1<redacted>"),
+        (#"(?i)("[^"]*(?:token|secret|password|recovery_codes)[^"]*"\s*:\s*)("[^"]*")"#, "$1\"<redacted>\""),
+        (#"(?i)\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b"#, "<redacted>"),
+    ]
+
+    return replacements.reduce(text) { result, replacement in
+        result.replacingOccurrences(
+            of: replacement.0,
+            with: replacement.1,
+            options: .regularExpression
+        )
+    }
 }
 
 public enum PutioSDKErrorType {
@@ -391,7 +425,7 @@ public struct PutioSDKError: Error, LocalizedError, CustomStringConvertible, Cus
     }
 
     public var errorDescription: String? {
-        message
+        redactedMessage
     }
 
     public var failureReason: String? {
@@ -412,7 +446,7 @@ public struct PutioSDKError: Error, LocalizedError, CustomStringConvertible, Cus
     }
 
     public var description: String {
-        "PutioSDKError(request: \(request), type: \(type), message: \"\(message)\", underlyingError: \(underlyingError), responseBody: \(responseBody ?? "nil"))"
+        "PutioSDKError(request: \(request), type: \(type), message: \"\(redactedMessage)\", underlyingError: \(underlyingError), responseBody: \(redactedResponseBodyDescription))"
     }
 
     public var debugDescription: String {
@@ -478,6 +512,18 @@ public struct PutioSDKError: Error, LocalizedError, CustomStringConvertible, Cus
         self.message = error.localizedDescription
         self.underlyingError = error
         self.responseBody = nil
+    }
+
+    private var redactedResponseBodyDescription: String {
+        guard let responseBody else {
+            return "nil"
+        }
+
+        return "<redacted body, \(responseBody.utf8.count) bytes>"
+    }
+
+    private var redactedMessage: String {
+        redactSensitiveText(message)
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ The example app shows a minimal `ASWebAuthenticationSession` flow and a follow-u
 - [Example/PutioSDK/ViewController.swift](./Example/PutioSDK/ViewController.swift)
 - [Example app guide](./Example/README.md)
 
+Use `try PutioSDK.generateOAuthState()` with `getAuthURL(redirectURI:state:)`, then validate the returned callback state before accepting `access_token`.
+
 ## Docs
 
 - [Example app](./Example) for the example app and smoke-test workspace

--- a/Tests/PutioSDKTests/PutioSDKAuthTests.swift
+++ b/Tests/PutioSDKTests/PutioSDKAuthTests.swift
@@ -26,6 +26,57 @@ final class PutioSDKAuthTests: XCTestCase {
         XCTAssertEqual(query["state"], "csrf-token")
     }
 
+    func testGenerateOAuthStateProducesURLSafeHighEntropyValue() throws {
+        let state = try PutioSDK.generateOAuthState()
+        let secondState = try PutioSDK.generateOAuthState()
+
+        XCTAssertGreaterThanOrEqual(state.count, 32)
+        XCTAssertNotEqual(state, secondState)
+        XCTAssertFalse(state.contains("+"))
+        XCTAssertFalse(state.contains("/"))
+        XCTAssertFalse(state.contains("="))
+        XCTAssertThrowsError(try PutioSDK.generateOAuthState(byteCount: 0)) { error in
+            XCTAssertEqual(error as? PutioOAuthStateError, .invalidByteCount)
+        }
+    }
+
+    func testOAuthCallbackParserValidatesCallbackAndStateBeforeReturningToken() throws {
+        let sdk = PutioSDK(
+            config: PutioSDKConfig(clientID: "ios-app", clientName: "put.io TV + Beta", token: "session-token"),
+            urlSession: makeTestSession()
+        )
+        let callbackURL = try XCTUnwrap(URL(string: "putioswift://auth#access_token=token-123&state=csrf-token"))
+
+        let token = try sdk.accessToken(
+            fromOAuthCallback: callbackURL,
+            expectedScheme: "putioswift",
+            expectedHost: "auth",
+            expectedState: "csrf-token"
+        )
+
+        XCTAssertEqual(token, "token-123")
+        XCTAssertThrowsError(
+            try sdk.accessToken(
+                fromOAuthCallback: callbackURL,
+                expectedScheme: "putioswift",
+                expectedHost: "auth",
+                expectedState: "wrong-state"
+            )
+        ) { error in
+            XCTAssertEqual(error as? PutioOAuthCallbackError, .invalidState)
+        }
+        XCTAssertThrowsError(
+            try sdk.accessToken(
+                fromOAuthCallback: callbackURL,
+                expectedScheme: "putioswift",
+                expectedHost: "other",
+                expectedState: "csrf-token"
+            )
+        ) { error in
+            XCTAssertEqual(error as? PutioOAuthCallbackError, .invalidCallbackURL)
+        }
+    }
+
     func testAuthAndTwoFactorEndpointsDecodeTypedResponses() async throws {
         var seenPaths: [String] = []
 

--- a/Tests/PutioSDKTests/PutioSDKErrorTests.swift
+++ b/Tests/PutioSDKTests/PutioSDKErrorTests.swift
@@ -142,8 +142,13 @@ final class PutioSDKErrorTests: XCTestCase {
             url: "/two_factor/verify/totp",
             method: .post,
             headers: ["Authorization": "Bearer header-token"],
-            query: ["oauth_token": "query-token"],
-            body: ["client_secret": "client-secret", "name": "safe-name"]
+            query: ["oauth_token": "query-token", "password": "password"],
+            body: [
+                "client_secret": "client-secret",
+                "current_password": "current_password",
+                "profile": .object(["totp_secret": "totp-secret"]),
+                "name": "safe-name",
+            ]
         )
         let requestInfo = PutioSDKErrorRequestInformation(config: requestConfig)
         let error = PutioSDKError(
@@ -160,9 +165,55 @@ final class PutioSDKErrorTests: XCTestCase {
         XCTAssertFalse(description.contains("header-token"))
         XCTAssertFalse(description.contains("query-token"))
         XCTAssertFalse(description.contains("client-secret"))
+        XCTAssertFalse(description.contains("password"))
+        XCTAssertFalse(description.contains("current_password"))
+        XCTAssertFalse(description.contains("totp-secret"))
         XCTAssertTrue(description.contains("safe-name"))
         XCTAssertTrue(description.contains("<redacted>"))
         XCTAssertFalse(error.failureReason?.contains("query-token") == true)
+    }
+
+    func testErrorDescriptionRedactsRawResponseBodyButKeepsExplicitProperty() {
+        let requestConfig = PutioSDKRequestConfig(
+            apiConfig: PutioSDKConfig(clientID: "ios-app", token: "token-123"),
+            url: "/account/info",
+            method: .get
+        )
+        let requestInfo = PutioSDKErrorRequestInformation(config: requestConfig)
+        let rawBody = """
+        {
+          "email": "person@example.com",
+          "access_token": "response-token",
+          "download_url": "https://example.com/file?oauth_token=url-token"
+        }
+        """
+        let error = PutioSDKError(
+            request: requestInfo,
+            statusCode: 403,
+            errorType: "forbidden",
+            message: #"safe failure for person@example.com with access_token=response-token and {"client_secret":"message-secret"}"#,
+            underlyingError: URLError(.userAuthenticationRequired),
+            responseBody: rawBody
+        )
+
+        let description = String(describing: error)
+        let debugDescription = String(reflecting: error)
+
+        XCTAssertFalse(description.contains("person@example.com"))
+        XCTAssertFalse(description.contains("response-token"))
+        XCTAssertFalse(description.contains("url-token"))
+        XCTAssertFalse(description.contains("message-secret"))
+        XCTAssertFalse(debugDescription.contains("person@example.com"))
+        XCTAssertFalse(debugDescription.contains("response-token"))
+        XCTAssertFalse(debugDescription.contains("message-secret"))
+        XCTAssertFalse(error.errorDescription?.contains("person@example.com") == true)
+        XCTAssertFalse(error.errorDescription?.contains("response-token") == true)
+        XCTAssertFalse(error.errorDescription?.contains("message-secret") == true)
+        XCTAssertTrue(description.contains("HTTP 403") || description.contains("statusCode: 403"))
+        XCTAssertTrue(description.contains("forbidden"))
+        XCTAssertTrue(description.contains("safe failure"))
+        XCTAssertTrue(description.contains("<redacted body,"))
+        XCTAssertEqual(error.responseBody, rawBody)
     }
 
     func testTransportNotifiesDelegateForNetworkAndDecodingFailures() async throws {


### PR DESCRIPTION
## Summary

Hardens the Swift SDK release workflow and sensitive error/auth surfaces.

## Validation

- [x] `make verify`
- [ ] `make live-test` when API behavior needs real backend evidence; not run because this changes local error rendering, CI configuration, and OAuth callback handling rather than live API contracts
- [ ] Example app smoke when auth, package installation, or request flow changes; not run interactively, but `make verify` rebuilt the example-backed CocoaPods `PutioSDK` scheme

## SDK Contract

- [x] Public API changes are intentional and documented
- [x] Request and response models are typed at the boundary
- [x] Error behavior includes useful recovery or retry guidance when applicable

## Risk

- Release-flow risk: actions and semantic-release plugins are now pinned; release still uses `putio-release-bot` and the protected `release` Environment
- Error-behavior risk: `PutioSDKError.responseBody` intentionally remains raw for explicit programmatic inspection, while stringification/localized output is redacted
- Auth-flow risk: the old no-state auth URL overload is deprecated for source compatibility; callers should pass a high-entropy state and validate callbacks
