### PR TITLE
ci: tighten release job token permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,9 +72,7 @@ jobs:
       name: release
       deployment: false
     permissions:
-      contents: write
-      issues: write
-      pull-requests: write
+      contents: read
 
     steps:
       - name: Create release bot token


### PR DESCRIPTION
## Summary

Tightens the release job default `GITHUB_TOKEN` to read-only. Release writes still use the minted `putio-release-bot` app token for checkout and semantic-release.

## Changed

- `.github/workflows/ci.yml`: set the release job permissions to `contents: read` only

## Risks

Future release steps that accidentally rely on the job `GITHUB_TOKEN` for writes would fail. The current write paths already use `steps.release-bot.outputs.token`.

## Verification

- `make verify`

## Complexity

Reduced: removes unnecessary default token write scopes.