### PR TITLE
feat(secrets): migrate live setup to SOPS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 # Live SDK verification env file.
-# Run `make secrets-setup` to materialize .env.local from Infisical.
+# Set PUTIO_SDK_SWIFT_SOPS_FILE to an authorized ciphertext file, then run
+# `make secrets-setup` to validate and materialize ignored .env.local.
+# PUTIO_SDK_SWIFT_SOPS_FILE=/path/to/swift.sops.env
 
 PUTIO_TOKEN_FIRST_PARTY=""
 PUTIO_CLIENT_ID=""

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,14 +24,14 @@
 ## Worktrees
 
 `.worktreeinclude` carries `.env` and Bundler config into Codex and Claude
-worktrees. Run `make bootstrap`; use `make secrets-setup` if live-test env is
-missing or stale.
+worktrees. Run `make bootstrap`; use `make secrets-setup` with
+`PUTIO_SDK_SWIFT_SOPS_FILE` if live-test env is missing or stale.
 
 ## Repo-Specific Guidance
 
 - Keep the public package surface open-source-safe
 - Prefer the `make verify` entrypoint instead of ad hoc validation commands
-- Live tests expect maintainer-supplied `PUTIO_SDK_SWIFT_INFISICAL_*`; `make secrets-setup` writes ignored `.env.local`, and `make secrets-clean` removes it.
+- Live tests accept maintainer-supplied `PUTIO_SDK_SWIFT_SOPS_FILE`; `make secrets-setup` validates and writes ignored `.env.local`, and `make secrets-clean` removes it.
 - The GitHub repository is `putio-sdk-swift`
 - The Swift Package surface is `PutioSDK`
 - The CocoaPods package is `PutioSDK`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,18 @@ make live-test
 
 The live suite prefers direct runtime env vars first and can optionally hydrate credentials from repo-local operator configuration. See [Testing](./docs/TESTING.md) for the supported public variables and safety rules.
 
+Maintainers with an authorized age identity can materialize the supplied SOPS
+ciphertext into an ignored owner-only env file:
+
+```bash
+PUTIO_SDK_SWIFT_SOPS_FILE=/path/to/swift.sops.env make secrets-setup
+make live-test
+make secrets-clean
+```
+
+`secrets-setup` requires SOPS 3.10 or newer. Keep ciphertext coordinates and
+private age identities outside this public repository.
+
 To see the concrete iPhone simulator destination Xcode is advertising to the repo on your machine, run:
 
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,13 @@
-.PHONY: bootstrap verify verify-spm coverage-check live-test example-install print-simulator-destination secrets-setup secrets-clean clean
+.PHONY: bootstrap verify verify-spm coverage-check live-test test-secrets example-install print-simulator-destination secrets-setup secrets-clean clean
 
 SECRETS_OUTPUT ?= .env.local
-PUTIO_INFISICAL_DOMAIN ?= https://eu.infisical.com/api
-PUTIO_SDK_SWIFT_INFISICAL_ENV ?= dev
 
 bootstrap:
 	bundle config set --local path vendor/bundle
 	bundle install
 
 verify:
+	./scripts/secrets-setup.test.sh
 	swift test --enable-code-coverage --filter PutioSDKTests
 	./scripts/check-spm-coverage.sh 90
 	swift build
@@ -31,15 +30,11 @@ coverage-check:
 live-test:
 	swift test --filter PutioSDKLiveTests
 
+test-secrets:
+	./scripts/secrets-setup.test.sh
+
 secrets-setup:
-	@set -eu; \
-	: "$${PUTIO_SDK_SWIFT_INFISICAL_PROJECT_ID:?Set PUTIO_SDK_SWIFT_INFISICAL_PROJECT_ID for this repo}"; \
-	: "$${PUTIO_SDK_SWIFT_INFISICAL_PATH:?Set PUTIO_SDK_SWIFT_INFISICAL_PATH for this repo}"; \
-	umask 077; \
-	tmp="$$(mktemp)"; \
-	trap 'rm -f "$$tmp"' EXIT; \
-	infisical export --silent --domain "$(PUTIO_INFISICAL_DOMAIN)" --projectId "$$PUTIO_SDK_SWIFT_INFISICAL_PROJECT_ID" --env "$(PUTIO_SDK_SWIFT_INFISICAL_ENV)" --path "$$PUTIO_SDK_SWIFT_INFISICAL_PATH" --format dotenv --output-file "$$tmp"; \
-	install -m 600 "$$tmp" "$(SECRETS_OUTPUT)"
+	./scripts/secrets-setup.sh
 
 secrets-clean:
 	rm -f .env.local .env.local.* .env.local.swp

--- a/Tests/PutioSDKLiveTests/PutioSDKLiveTests.swift
+++ b/Tests/PutioSDKLiveTests/PutioSDKLiveTests.swift
@@ -23,6 +23,7 @@ final class PutioSDKLiveTests: XCTestCase {
 
     func testFilesAndTrashDisposableFlow() async throws {
         let sdk = try LiveSupport.newAuthedClient()
+        let trashEnabled = try await sdk.getAccountSettings().trashEnabled
         let folderName = LiveSupport.uniqueName(prefix: "putio-swift-live")
 
         let created = try await sdk.createFolder(name: folderName, parentID: 0)
@@ -34,6 +35,8 @@ final class PutioSDKLiveTests: XCTestCase {
             XCTAssertTrue(listing.children.contains(where: { $0.id == createdID }))
 
             _ = try await sdk.deleteFiles(fileIDs: [createdID])
+
+            try XCTSkipIf(!trashEnabled, "Live test account has trash disabled")
 
             let trash = try await sdk.listTrash()
             XCTAssertTrue(trash.files.contains(where: { $0.id == createdID }))

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -34,9 +34,12 @@ Supported public runtime variables:
 - `PUTIO_CLIENT_ID`
 - `PUTIO_BASE_URL`
 
-Run `make secrets-setup` to render shared live credentials from the Infisical
-`/sdk-swift` path into `.env.local`. The live harness auto-loads `.env.local`
-and `.env`; already-exported environment variables keep highest priority.
+Run `make secrets-setup` with `PUTIO_SDK_SWIFT_SOPS_FILE` pointing to the
+maintainer-supplied SOPS ciphertext. The command requires SOPS 3.10 or newer,
+rejects plaintext or malformed payloads, and writes owner-only `.env.local`.
+The live harness auto-loads `.env.local` and `.env`; already-exported
+environment variables keep highest priority. Run `make secrets-clean` before
+removing the worktree.
 
 ## Live Scope
 
@@ -46,6 +49,10 @@ Current live targets cover:
 - disposable folder create, delete, trash restore, and cleanup flows
 - transfer list/count/info decode against the real API
 - playback-adjacent subtitle decode and reversible start-from roundtrips for owned video fixtures
+
+The disposable flow still proves create, list, and delete when the live account
+has trash disabled; restore coverage is reported as skipped instead of changing
+the shared account setting.
 
 ## Safety Rules
 

--- a/scripts/secrets-render.swift
+++ b/scripts/secrets-render.swift
@@ -1,0 +1,108 @@
+#!/usr/bin/env swift
+
+import Foundation
+
+enum RenderError: Error, CustomStringConvertible {
+    case invalidArguments
+    case invalidPayload
+    case invalidInventory
+    case invalidValue
+    case invalidIdentifier
+    case unsafeValue
+
+    var description: String {
+        switch self {
+        case .invalidArguments:
+            return "expected payload and output paths"
+        case .invalidPayload:
+            return "decrypted payload must be a JSON object"
+        case .invalidInventory:
+            return "decrypted payload key inventory does not match the SDK contract"
+        case .invalidValue:
+            return "decrypted payload contains an empty, non-string, quote-wrapped, or control-character value"
+        case .invalidIdentifier:
+            return "decrypted payload contains an invalid numeric identifier"
+        case .unsafeValue:
+            return "decrypted payload contains a value that cannot be rendered safely"
+        }
+    }
+}
+
+func render(_ value: String) throws -> String {
+    if !value.contains("\"") {
+        return "\"\(value)\""
+    }
+
+    if !value.contains("'") {
+        return "'\(value)'"
+    }
+
+    throw RenderError.unsafeValue
+}
+
+do {
+    guard CommandLine.arguments.count == 3 else {
+        throw RenderError.invalidArguments
+    }
+
+    let payloadPath = CommandLine.arguments[1]
+    let outputPath = CommandLine.arguments[2]
+    let data = try Data(contentsOf: URL(fileURLWithPath: payloadPath))
+    let decoded = try JSONSerialization.jsonObject(with: data)
+
+    guard let payload = decoded as? [String: String] else {
+        throw RenderError.invalidPayload
+    }
+
+    let expectedKeys = [
+        "PUTIO_CLIENT_ID",
+        "PUTIO_TOKEN_FIRST_PARTY",
+        "PUTIO_TOKEN_THIRD_PARTY",
+    ]
+    let actualKeys = payload.keys.sorted()
+
+    guard actualKeys == expectedKeys else {
+        throw RenderError.invalidInventory
+    }
+
+    for key in actualKeys {
+        guard let value = payload[key], !value.isEmpty else {
+            throw RenderError.invalidValue
+        }
+
+        let quoteWrapped = value.count >= 2
+            && ((value.hasPrefix("\"") && value.hasSuffix("\""))
+                || (value.hasPrefix("'") && value.hasSuffix("'")))
+        let hasControlCharacter = value.unicodeScalars.contains { scalar in
+            scalar.value == 0 || scalar.value == 10 || scalar.value == 13
+        }
+
+        guard !quoteWrapped, !hasControlCharacter else {
+            throw RenderError.invalidValue
+        }
+    }
+
+    guard payload["PUTIO_CLIENT_ID"]?.allSatisfy({ $0 >= "0" && $0 <= "9" }) == true else {
+        throw RenderError.invalidIdentifier
+    }
+
+    let dotenv = try actualKeys
+        .map { key -> String in
+            guard let value = payload[key] else {
+                throw RenderError.invalidPayload
+            }
+
+            return "\(key)=\(try render(value))"
+        }
+        .joined(separator: "\n") + "\n"
+    let outputURL = URL(fileURLWithPath: outputPath)
+
+    try Data(dotenv.utf8).write(to: outputURL, options: .atomic)
+    try FileManager.default.setAttributes(
+        [.posixPermissions: 0o600],
+        ofItemAtPath: outputPath
+    )
+} catch {
+    FileHandle.standardError.write(Data("FAILED: \(error)\n".utf8))
+    exit(1)
+}

--- a/scripts/secrets-render.swift
+++ b/scripts/secrets-render.swift
@@ -73,8 +73,8 @@ do {
         let quoteWrapped = value.count >= 2
             && ((value.hasPrefix("\"") && value.hasSuffix("\""))
                 || (value.hasPrefix("'") && value.hasSuffix("'")))
-        let hasControlCharacter = value.unicodeScalars.contains { scalar in
-            scalar.value == 0 || scalar.value == 10 || scalar.value == 13
+        let hasControlCharacter = value.unicodeScalars.contains {
+            CharacterSet.controlCharacters.contains($0)
         }
 
         guard !quoteWrapped, !hasControlCharacter else {

--- a/scripts/secrets-setup.sh
+++ b/scripts/secrets-setup.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+umask 077
+
+fail() {
+  printf 'FAILED: %s\n' "$1" >&2
+  exit 1
+}
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+ciphertext="${PUTIO_SDK_SWIFT_SOPS_FILE:?Set PUTIO_SDK_SWIFT_SOPS_FILE to the SDK ciphertext file}"
+output="${SECRETS_OUTPUT:-.env.local}"
+
+command -v sops >/dev/null 2>&1 || fail "sops is required"
+command -v swift >/dev/null 2>&1 || fail "swift is required"
+
+[ -f "$ciphertext" ] || fail "ciphertext input must be one regular file"
+[ ! -L "$ciphertext" ] || fail "ciphertext input must not be a symlink"
+case "$output" in
+  /*|..|../*|*/../*) fail "SECRETS_OUTPUT must be a repository-relative ignored path" ;;
+esac
+git check-ignore -q -- "$output" || fail "output path is not gitignored: $output"
+[ ! -L "$output" ] || fail "output path must not be a symlink: $output"
+[ ! -e "$output" ] || [ -f "$output" ] || fail "output path must be a regular file: $output"
+
+status="$(sops filestatus --input-type dotenv "$ciphertext" 2>/dev/null)" \
+  || fail "SOPS 3.10 or newer could not inspect the dotenv ciphertext input"
+printf '%s\n' "$status" | grep -Eq '"encrypted"[[:space:]]*:[[:space:]]*true' \
+  || fail "ciphertext input is not encrypted"
+
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/putio-sdk-swift-secrets.XXXXXX")"
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+payload_json="$tmp_dir/payload.json"
+rendered_env="$tmp_dir/rendered.env"
+module_cache="$tmp_dir/swift-module-cache"
+mkdir -p "$module_cache"
+sops decrypt --output-type json --output "$payload_json" "$ciphertext" \
+  || fail "could not decrypt ciphertext input"
+chmod 600 "$payload_json"
+
+SWIFT_MODULECACHE_PATH="$module_cache" CLANG_MODULE_CACHE_PATH="$module_cache" \
+  swift ./scripts/secrets-render.swift "$payload_json" "$rendered_env" \
+  || fail "decrypted payload failed validation or safe dotenv rendering"
+install -m 600 "$rendered_env" "$output"
+printf 'ok wrote %s\n' "$output"

--- a/scripts/secrets-setup.sh
+++ b/scripts/secrets-setup.sh
@@ -12,18 +12,28 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
 ciphertext="${PUTIO_SDK_SWIFT_SOPS_FILE:?Set PUTIO_SDK_SWIFT_SOPS_FILE to the SDK ciphertext file}"
-output="${SECRETS_OUTPUT:-.env.local}"
+output="${SECRETS_OUTPUT-.env.local}"
 
 command -v sops >/dev/null 2>&1 || fail "sops is required"
 command -v swift >/dev/null 2>&1 || fail "swift is required"
 
 [ -f "$ciphertext" ] || fail "ciphertext input must be one regular file"
 [ ! -L "$ciphertext" ] || fail "ciphertext input must not be a symlink"
+[ -n "$output" ] || fail "SECRETS_OUTPUT must not be empty"
 case "$output" in
   /*|..|../*|*/../*) fail "SECRETS_OUTPUT must be a repository-relative ignored path" ;;
 esac
 git check-ignore -q -- "$output" || fail "output path is not gitignored: $output"
-[ ! -L "$output" ] || fail "output path must not be a symlink: $output"
+
+output_component="$output"
+while [ "$output_component" != "." ]; do
+  [ ! -L "$output_component" ] \
+    || fail "output path must not contain symlinks: $output_component"
+  parent_component="$(dirname "$output_component")"
+  [ "$parent_component" != "$output_component" ] || break
+  output_component="$parent_component"
+done
+
 [ ! -e "$output" ] || [ -f "$output" ] || fail "output path must be a regular file: $output"
 
 status="$(sops filestatus --input-type dotenv "$ciphertext" 2>/dev/null)" \

--- a/scripts/secrets-setup.test.sh
+++ b/scripts/secrets-setup.test.sh
@@ -123,6 +123,10 @@ write_payload '{"PUTIO_CLIENT_ID":"123","PUTIO_TOKEN_FIRST_PARTY":"before\u0000a
 expect_failure run_setup
 [ ! -e "$output" ]
 
+write_payload '{"PUTIO_CLIENT_ID":"123","PUTIO_TOKEN_FIRST_PARTY":"before\tafter","PUTIO_TOKEN_THIRD_PARTY":"third"}'
+expect_failure run_setup
+[ ! -e "$output" ]
+
 write_valid_payload
 expect_failure env \
   PATH="$tmp_dir/bin:$PATH" \
@@ -140,6 +144,13 @@ expect_failure env \
   SECRETS_OUTPUT=README.md \
   bash ./scripts/secrets-setup.sh
 
+expect_failure env \
+  PATH="$tmp_dir/bin:$PATH" \
+  FAKE_SOPS_PAYLOAD="$payload" \
+  PUTIO_SDK_SWIFT_SOPS_FILE="$ciphertext" \
+  SECRETS_OUTPUT= \
+  bash ./scripts/secrets-setup.sh
+
 symlinked_ciphertext="$tmp_dir/symlinked.sops.env"
 ln -s "$ciphertext" "$symlinked_ciphertext"
 expect_failure env \
@@ -151,5 +162,17 @@ expect_failure env \
 
 ln -s "$tmp_dir/redirected.env" "$output"
 expect_failure run_setup
+rm -f "$output"
+
+symlinked_parent=".env.local.sops-parent.$$"
+mkdir -p "$tmp_dir/outside"
+ln -s "$tmp_dir/outside" "$symlinked_parent"
+expect_failure env \
+  PATH="$tmp_dir/bin:$PATH" \
+  FAKE_SOPS_PAYLOAD="$payload" \
+  PUTIO_SDK_SWIFT_SOPS_FILE="$ciphertext" \
+  SECRETS_OUTPUT="$symlinked_parent/rendered.env" \
+  bash ./scripts/secrets-setup.sh
+rm -f "$symlinked_parent"
 
 printf 'ok SOPS setup renders validated ignored output and fails closed\n'

--- a/scripts/secrets-setup.test.sh
+++ b/scripts/secrets-setup.test.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+umask 077
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/putio-sdk-swift-secrets-test.XXXXXX")"
+output=".env.local.sops-test.$$"
+cleanup() {
+  rm -rf "$tmp_dir"
+  rm -f "$output"
+}
+trap cleanup EXIT
+
+mkdir -p "$tmp_dir/bin"
+fake_sops="$tmp_dir/bin/sops"
+cat >"$fake_sops" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+  filestatus)
+    [ "${2:-}" = "--input-type" ]
+    [ "${3:-}" = "dotenv" ]
+    printf '{"encrypted":%s}\n' "${FAKE_SOPS_ENCRYPTED:-true}"
+    ;;
+  decrypt)
+    output=""
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --output)
+          shift
+          output="$1"
+          ;;
+      esac
+      shift
+    done
+    [ -n "$output" ]
+    install -m 600 "$FAKE_SOPS_PAYLOAD" "$output"
+    ;;
+  *)
+    exit 2
+    ;;
+esac
+SH
+chmod 700 "$fake_sops"
+
+ciphertext="$tmp_dir/payload.sops.env"
+payload="$tmp_dir/payload.json"
+printf 'ciphertext fixture\n' >"$ciphertext"
+
+write_payload() {
+  printf '%s\n' "$1" >"$payload"
+}
+
+write_valid_payload() {
+  write_payload '{"PUTIO_CLIENT_ID":"123","PUTIO_TOKEN_FIRST_PARTY":"token with spaces = yes","PUTIO_TOKEN_THIRD_PARTY":"token with \"double\" quotes"}'
+}
+
+run_setup() {
+  PATH="$tmp_dir/bin:$PATH" \
+  FAKE_SOPS_PAYLOAD="$payload" \
+  PUTIO_SDK_SWIFT_SOPS_FILE="$ciphertext" \
+  SECRETS_OUTPUT="$output" \
+    bash ./scripts/secrets-setup.sh
+}
+
+expect_failure() {
+  if "$@" >/dev/null 2>&1; then
+    printf 'FAILED: command unexpectedly succeeded\n' >&2
+    exit 1
+  fi
+}
+
+write_valid_payload
+run_setup >/dev/null
+if output_mode="$(stat -c '%a' "$output" 2>/dev/null)"; then
+  :
+else
+  output_mode="$(stat -f '%Lp' "$output")"
+fi
+[ "$output_mode" = 600 ]
+grep -Fx 'PUTIO_CLIENT_ID="123"' "$output" >/dev/null
+grep -Fx 'PUTIO_TOKEN_FIRST_PARTY="token with spaces = yes"' "$output" >/dev/null
+grep -Fx 'PUTIO_TOKEN_THIRD_PARTY='"'"'token with "double" quotes'"'"'' "$output" >/dev/null
+rm -f "$output"
+
+write_payload '{"PUTIO_TOKEN_FIRST_PARTY":"first","PUTIO_TOKEN_THIRD_PARTY":"third"}'
+expect_failure run_setup
+[ ! -e "$output" ]
+
+write_payload '{"PUTIO_CLIENT_ID":"123","PUTIO_TOKEN_FIRST_PARTY":"first","PUTIO_TOKEN_THIRD_PARTY":"third","UNEXPECTED":"value"}'
+expect_failure run_setup
+[ ! -e "$output" ]
+
+write_payload '{"PUTIO_CLIENT_ID":"123","PUTIO_TOKEN_FIRST_PARTY":"","PUTIO_TOKEN_THIRD_PARTY":"third"}'
+expect_failure run_setup
+[ ! -e "$output" ]
+
+write_payload '{"PUTIO_CLIENT_ID":"not-numeric","PUTIO_TOKEN_FIRST_PARTY":"first","PUTIO_TOKEN_THIRD_PARTY":"third"}'
+expect_failure run_setup
+[ ! -e "$output" ]
+
+write_payload '{"PUTIO_CLIENT_ID":"123","PUTIO_TOKEN_FIRST_PARTY":"\"quoted\"","PUTIO_TOKEN_THIRD_PARTY":"third"}'
+expect_failure run_setup
+[ ! -e "$output" ]
+
+write_payload '{"PUTIO_CLIENT_ID":"123","PUTIO_TOKEN_FIRST_PARTY":"'"'"'quoted'"'"'","PUTIO_TOKEN_THIRD_PARTY":"third"}'
+expect_failure run_setup
+[ ! -e "$output" ]
+
+write_payload '{"PUTIO_CLIENT_ID":"123","PUTIO_TOKEN_FIRST_PARTY":"single'"'"' and \"double\"","PUTIO_TOKEN_THIRD_PARTY":"third"}'
+expect_failure run_setup
+[ ! -e "$output" ]
+
+write_payload '{"PUTIO_CLIENT_ID":"123","PUTIO_TOKEN_FIRST_PARTY":"line one\nline two","PUTIO_TOKEN_THIRD_PARTY":"third"}'
+expect_failure run_setup
+[ ! -e "$output" ]
+
+write_payload '{"PUTIO_CLIENT_ID":"123","PUTIO_TOKEN_FIRST_PARTY":"before\u0000after","PUTIO_TOKEN_THIRD_PARTY":"third"}'
+expect_failure run_setup
+[ ! -e "$output" ]
+
+write_valid_payload
+expect_failure env \
+  PATH="$tmp_dir/bin:$PATH" \
+  FAKE_SOPS_ENCRYPTED=false \
+  FAKE_SOPS_PAYLOAD="$payload" \
+  PUTIO_SDK_SWIFT_SOPS_FILE="$ciphertext" \
+  SECRETS_OUTPUT="$output" \
+  bash ./scripts/secrets-setup.sh
+[ ! -e "$output" ]
+
+expect_failure env \
+  PATH="$tmp_dir/bin:$PATH" \
+  FAKE_SOPS_PAYLOAD="$payload" \
+  PUTIO_SDK_SWIFT_SOPS_FILE="$ciphertext" \
+  SECRETS_OUTPUT=README.md \
+  bash ./scripts/secrets-setup.sh
+
+symlinked_ciphertext="$tmp_dir/symlinked.sops.env"
+ln -s "$ciphertext" "$symlinked_ciphertext"
+expect_failure env \
+  PATH="$tmp_dir/bin:$PATH" \
+  FAKE_SOPS_PAYLOAD="$payload" \
+  PUTIO_SDK_SWIFT_SOPS_FILE="$symlinked_ciphertext" \
+  SECRETS_OUTPUT="$output" \
+  bash ./scripts/secrets-setup.sh
+
+ln -s "$tmp_dir/redirected.env" "$output"
+expect_failure run_setup
+
+printf 'ok SOPS setup renders validated ignored output and fails closed\n'


### PR DESCRIPTION
## Summary

Replace the Swift SDK live-test Infisical wrapper with a generic, fail-closed SOPS ciphertext input. The public repo receives only an operator-supplied file path; private vault coordinates remain outside the repository.

## Changed

- added a Swift-native exact payload validator and safe dotenv renderer
- made secrets setup reject plaintext, malformed inventories, empty or wrapped values, unsafe control characters, symlink inputs and outputs, and non-ignored destinations
- materialize ignored env output with mode 0600 and clean temporary plaintext automatically
- added deterministic setup and failure-path coverage to the default verification gate
- made disabled trash support an explicit live-test skip instead of a false restore failure
- updated contributor, testing, example-env, and agent guidance

## Review aids

Sanitized behavior contract:

| Input | Output |
| --- | --- |
| Authorized encrypted dotenv payload with exactly 3 SDK keys | Validated, ignored mode-0600 .env.local |
| Plaintext, wrong keys, empty/wrapped/control-character values, symlinks, or tracked destination | Actionable failure and no output file |

## Validation

- [x] full make verify under the repo Ruby 3.2.4 toolchain
- [x] 49 deterministic tests passed
- [x] source coverage passed at 90.76 percent
- [x] Swift package and CocoaPods simulator framework builds passed
- [x] real ciphertext rendered into ignored mode-0600 output
- [x] live lane passed: 4 tests passed, 1 explicitly skipped because the shared account has trash disabled, 0 failures

## SDK Contract

- [x] no public SDK API changes
- [x] decrypted input is parsed and validated at the setup boundary
- [x] failures name the recovery action without printing secret material

## Risk

Local live-test setup now requires SOPS 3.10 or newer and an authorized age identity. CI, releases, and protected repository secrets are unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated live secrets setup from Infisical to fail-closed `sops` ciphertext with Swift-side validation and safe `.env.local` rendering. Improves safety, keeps vault coordinates out of the repo, and stabilizes live tests.

- **New Features**
  - Added Swift payload validator and safe dotenv renderer.
  - `make secrets-setup` decrypts `PUTIO_SDK_SWIFT_SOPS_FILE`, validates, and writes ignored `.env.local` (0600); rejects plaintext/malformed payloads, non-numeric IDs, control chars, and quote-wrapped values.
  - Hardened output handling: require repo-relative gitignored path, forbid absolute/`..` segments, block symlinked inputs/outputs/parents, and reject non-regular outputs.
  - Deterministic coverage via `scripts/secrets-setup.test.sh` (in `make verify` and `make test-secrets`).
  - Live trash restore test is skipped when the account has trash disabled.

- **Migration**
  - Requires `sops` 3.10+, `swift`, and an authorized `age` identity.
  - Set `PUTIO_SDK_SWIFT_SOPS_FILE=/path/to/swift.sops.env`, run `make secrets-setup`, then `make live-test`; use `make secrets-clean` to remove output.
  - Infisical-based setup is removed; CI and protected secrets remain unchanged.

<sup>Written for commit 9e561ec83e2ef0171090a64f5bbe29350dff7b84. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

