### PR TITLE
ci(release): resolve releaser bot user id at runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,17 +89,18 @@ jobs:
           permission-pull-requests: write
       - name: Resolve release bot identity
         id: release-bot-identity
+        shell: bash
         env:
           GH_TOKEN: ${{ steps.release-bot.outputs.token }}
           APP_SLUG: ${{ steps.release-bot.outputs.app-slug }}
         run: |
           set -euo pipefail
-          user_id="$(gh api "/users/${APP_SLUG}[bot]" --jq .id)"
+          user_id="$(gh api "/users/${APP_SLUG}%5Bbot%5D" --jq .id)"
           if [[ ! "$user_id" =~ ^[0-9]+$ ]]; then
             echo "failed to resolve numeric bot user id for ${APP_SLUG}[bot]" >&2
             exit 1
           fi
-          echo "user-id=${user_id}" >> "$GITHUB_OUTPUT"
+          echo "user_id=${user_id}" >> "$GITHUB_OUTPUT"
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -150,6 +151,6 @@ jobs:
           GITHUB_TOKEN: ${{ steps.release-bot.outputs.token }}
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
           GIT_AUTHOR_NAME: ${{ steps.release-bot.outputs.app-slug }}[bot]
-          GIT_AUTHOR_EMAIL: ${{ steps.release-bot-identity.outputs.user-id }}+${{ steps.release-bot.outputs.app-slug }}[bot]@users.noreply.github.com
+          GIT_AUTHOR_EMAIL: ${{ steps.release-bot-identity.outputs.user_id }}+${{ steps.release-bot.outputs.app-slug }}[bot]@users.noreply.github.com
           GIT_COMMITTER_NAME: ${{ steps.release-bot.outputs.app-slug }}[bot]
-          GIT_COMMITTER_EMAIL: ${{ steps.release-bot-identity.outputs.user-id }}+${{ steps.release-bot.outputs.app-slug }}[bot]@users.noreply.github.com
+          GIT_COMMITTER_EMAIL: ${{ steps.release-bot-identity.outputs.user_id }}+${{ steps.release-bot.outputs.app-slug }}[bot]@users.noreply.github.com

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,19 @@ jobs:
           permission-contents: write
           permission-issues: write
           permission-pull-requests: write
+      - name: Resolve release bot identity
+        id: release-bot-identity
+        env:
+          GH_TOKEN: ${{ steps.release-bot.outputs.token }}
+          APP_SLUG: ${{ steps.release-bot.outputs.app-slug }}
+        run: |
+          set -euo pipefail
+          user_id="$(gh api "/users/${APP_SLUG}[bot]" --jq .id)"
+          if [[ ! "$user_id" =~ ^[0-9]+$ ]]; then
+            echo "failed to resolve numeric bot user id for ${APP_SLUG}[bot]" >&2
+            exit 1
+          fi
+          echo "user-id=${user_id}" >> "$GITHUB_OUTPUT"
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -137,6 +150,6 @@ jobs:
           GITHUB_TOKEN: ${{ steps.release-bot.outputs.token }}
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
           GIT_AUTHOR_NAME: ${{ steps.release-bot.outputs.app-slug }}[bot]
-          GIT_AUTHOR_EMAIL: 283001373+${{ steps.release-bot.outputs.app-slug }}[bot]@users.noreply.github.com
+          GIT_AUTHOR_EMAIL: ${{ steps.release-bot-identity.outputs.user-id }}+${{ steps.release-bot.outputs.app-slug }}[bot]@users.noreply.github.com
           GIT_COMMITTER_NAME: ${{ steps.release-bot.outputs.app-slug }}[bot]
-          GIT_COMMITTER_EMAIL: 283001373+${{ steps.release-bot.outputs.app-slug }}[bot]@users.noreply.github.com
+          GIT_COMMITTER_EMAIL: ${{ steps.release-bot-identity.outputs.user-id }}+${{ steps.release-bot.outputs.app-slug }}[bot]@users.noreply.github.com

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,9 +95,12 @@ jobs:
           APP_SLUG: ${{ steps.release-bot.outputs.app-slug }}
         run: |
           set -euo pipefail
-          user_id="$(gh api "/users/${APP_SLUG}%5Bbot%5D" --jq .id)"
-          if [[ ! "$user_id" =~ ^[0-9]+$ ]]; then
+          if ! user_id="$(gh api "/users/${APP_SLUG}%5Bbot%5D" --jq .id)"; then
             echo "failed to resolve numeric bot user id for ${APP_SLUG}[bot]" >&2
+            exit 1
+          fi
+          if [[ ! "$user_id" =~ ^[0-9]+$ ]]; then
+            echo "failed to resolve numeric bot user id for ${APP_SLUG}[bot] (got: ${user_id})" >&2
             exit 1
           fi
           echo "user_id=${user_id}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- Resolve the release bot numeric user id at runtime via `/users/{app-slug}[bot]`
- Use that id in noreply commit emails instead of a hardcoded value

## Test plan
- [ ] CI green on this PR
- [ ] Next release commit email links to `putio-releaser[bot]`

## Review aids
Before: `283001373+${{ steps.release-bot.outputs.app-slug }}[bot]@…`
After: `${{ steps.release-bot-identity.outputs.user-id }}+${{ steps.release-bot.outputs.app-slug }}[bot]@…`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve the release bot’s numeric user ID at runtime and use it in noreply commit emails. Keeps commit author links correct even if the GitHub App is recreated.

- **Refactors**
  - Fetch bot ID via `gh api "/users/${APP_SLUG}%5Bbot%5D"` in a bash step; validate numeric, include the app slug in errors, and expose as `user_id` (avoids Actions subtraction parsing).
  - Replace hardcoded `283001373` with `${{ steps.release-bot-identity.outputs.user_id }}` in `GIT_AUTHOR_EMAIL` and `GIT_COMMITTER_EMAIL`.

<sup>Written for commit 0a3d323fd9f06a08a5520f8b355339185690df6d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

