### PR TITLE
fix(release): move to v-prefixed tags and stop persisting the app token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-          token: ${{ steps.release-bot.outputs.token }}
+          persist-credentials: false
 
       - name: Select latest stable Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
@@ -139,6 +139,11 @@ jobs:
 
       - name: Bootstrap repository
         run: make bootstrap
+
+      - name: Configure release bot remote
+        run: git remote set-url origin "https://x-access-token:${RELEASE_BOT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+        env:
+          RELEASE_BOT_TOKEN: ${{ steps.release-bot.outputs.token }}
 
       - name: Release SDK
         uses: cycjimmy/semantic-release-action@b12c8f6015dc215fe37bc154d4ad456dd3833c90 # v6.0.0

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -2,7 +2,7 @@
   "branches": [
     "main"
   ],
-  "tagFormat": "${version}",
+  "tagFormat": "v${version}",
   "plugins": [
     [
       "@semantic-release/commit-analyzer",

--- a/podspec_helper.rb
+++ b/podspec_helper.rb
@@ -17,7 +17,7 @@ def configure_putio_sdk_spec(spec, name:, module_name: nil)
   spec.author           = { 'put.io' => 'devs@put.io' }
 
   spec.homepage         = 'https://github.com/putdotio/putio-sdk-swift'
-  spec.source           = { :git => 'https://github.com/putdotio/putio-sdk-swift.git', :tag => spec.version.to_s }
+  spec.source           = { :git => 'https://github.com/putdotio/putio-sdk-swift.git', :tag => "v#{spec.version}" }
   spec.social_media_url = 'https://twitter.com/putdotio'
 
   spec.ios.deployment_target = '26.0'


### PR DESCRIPTION
## Summary

Fixes #42 (WS0 of putdotio/putio-frontend#24).

**Problem 1 — unprotected release tags.** `.releaserc.json` set `tagFormat: "${version}"`, so every release tag (`3.2.0`, `3.1.1`, …46 tags total) is bare semver. The active `Protect v* release tags` ruleset matches only `refs/tags/v*` — it has never covered a single real release tag; all of them are deletable and movable.

**Problem 2 — persisted app token.** The release job's checkout passed `token: ${{ steps.release-bot.outputs.token }}` with default `persist-credentials: true`, writing the app token into `.git/config` for every later step (Xcode selection, Ruby setup, caches, bootstrap, semantic-release action).

### Fix 1: `tagFormat: "v${version}"` (option a)

Two options were on the table:

- **(a) switch to `v${version}`** — chosen. Matches the existing ruleset as authored, and matches the TS siblings: `putio-sdk-typescript` and `vref` set no `tagFormat`, so they use the semantic-release default `v${version}`. One repo stops being the outlier.
- **(b) keep bare tags, add a second tag ruleset** matching `refs/tags/[0-9]*` (rules: creation, update, deletion, non-fast-forward; same bypass actors). Rejected: it is a live-settings mutation outside this PR's diff, permanently diverges this repo from the sibling SDKs, and bare-semver ref patterns are easier to get wrong (a `3.*` pattern also matches non-release tags).

**Release continuity — read before merging.** semantic-release resolves the last release from tags matching `tagFormat`:

- **Before this change** it matches bare semver and resolves `3.2.0` → next release computed from commits since `3.2.0`.
- **After this change** it matches only `v`-prefixed semver. Zero `v*` tags exist today, so the next release run would see *no prior release*, restart at `v1.0.0`, and `pod trunk push` would then fail because `PutioSDK 1.0.0` is already published (trunk versions are immutable).

**Required pre-merge maintainer step** (needs `v*` tag-creation bypass; OrganizationAdmin has it):

```sh
git tag v3.2.0 709264177d7b8c9b7f00fb5a104e84c82519ac71 && git push origin v3.2.0
```

That is the commit `3.2.0` points at (`chore(sdk): release 3.2.0 [skip ci]`). With `v3.2.0` present, the next release resolves `v3.2.0` as the last release and versioning continues normally. Existing bare tags stay in place, so nothing already published breaks.

`podspec_helper.rb` changes in the same commit: `spec.source` pointed at `:tag => spec.version.to_s` (bare). Future trunk pushes must reference the new tag name, so it now uses `"v#{spec.version}"`. Ordering is safe: semantic-release creates and pushes the git tag before the `publish` phase runs `pod trunk push`. SwiftPM accepts both `X.Y.Z` and `vX.Y.Z` tags, so SPM consumers resolve old versions from the retained bare tags and new versions from `v*` tags.

### Fix 2: release checkout stops persisting the app token

Mirrors `putio-sdk-typescript`'s release job: checkout uses `persist-credentials: false` (and no `token:` input), and a dedicated `Configure release bot remote` step sets the authenticated push URL via `git remote set-url origin` immediately before the semantic-release step. The token now reaches git only through that remote URL and the action's env, not `.git/config` from checkout onward.

## Validation

- [x] `make verify` — green locally: Swift package tests `Executed 49 tests, with 0 failures`, example workspace `PutioSDK` CocoaPods scheme `** BUILD SUCCEEDED **`
- [ ] `make live-test` — not run; no API behavior change
- [ ] Example app smoke — not run; no auth, package-installation, or request-flow change

## SDK Contract

- [x] Public API changes are intentional and documented — none; release plumbing only
- [x] Request and response models are typed at the boundary — untouched
- [x] Error behavior includes useful recovery or retry guidance when applicable — untouched

## Risk

- Release-flow change. **Do not merge before pushing `v3.2.0`** (command above), or the next release restarts at `v1.0.0` and fails at CocoaPods trunk.
- First release after merge exercises the new remote-URL push path and v-tag creation (release bot is a ruleset bypass actor, Integration id 3648620) — watch that run.
- Adjacent findings routed to putdotio/putio-frontend#24, not fixed here: legacy `.md` issue template, no SwiftLint gate.