### PR TITLE
chore(release): recover partial CocoaPods releases safely

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 30
     concurrency:
-      group: verify-${{ github.workflow }}-${{ github.ref }}
+      group: verify-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
       cancel-in-progress: true
 
     steps:
@@ -280,9 +280,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          bundle config set --local path vendor/bundle
           bundle config set --local frozen true
-          bundle install --jobs 4 --retry 3
+          make bootstrap
 
       - name: Publish missing CocoaPods version
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,73 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      recover_version:
+        description: Existing version whose tag was created before publishing finished
+        required: true
+        type: string
 
 permissions:
   contents: read
 
 jobs:
+  validate_recovery:
+    if: github.event_name == 'workflow_dispatch'
+    name: Validate release recovery
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      tag: ${{ steps.validate.outputs.tag }}
+      version: ${{ steps.validate.outputs.version }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Validate recovery target
+        id: validate
+        shell: bash
+        env:
+          RAW_VERSION: ${{ inputs.recover_version }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
+            echo "release recovery must run from main (got: $GITHUB_REF)" >&2
+            exit 1
+          fi
+          if [[ ! "$RAW_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "recover_version must be a stable semantic version" >&2
+            exit 1
+          fi
+
+          version="$RAW_VERSION"
+          tag="v${version}"
+          current_version="$(tr -d '[:space:]' < VERSION)"
+          if [[ "$current_version" != "$version" ]]; then
+            echo "main VERSION is $current_version, not recovery version $version" >&2
+            exit 1
+          fi
+          if ! git rev-parse --verify --quiet "refs/tags/${tag}^{commit}" >/dev/null; then
+            echo "recovery tag $tag does not exist" >&2
+            exit 1
+          fi
+
+          tagged_version="$(git show "${tag}:VERSION" | tr -d '[:space:]')"
+          if [[ "$tagged_version" != "$version" ]]; then
+            echo "$tag contains VERSION $tagged_version, not $version" >&2
+            exit 1
+          fi
+
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
   verify:
     if: github.event_name != 'push' || !contains(github.event.head_commit.message, '[skip ci]')
     name: Verify Swift SDK
@@ -165,3 +227,86 @@ jobs:
           GIT_AUTHOR_EMAIL: ${{ steps.release-bot-identity.outputs.user_id }}+${{ steps.release-bot.outputs.app-slug }}[bot]@users.noreply.github.com
           GIT_COMMITTER_NAME: ${{ steps.release-bot.outputs.app-slug }}[bot]
           GIT_COMMITTER_EMAIL: ${{ steps.release-bot-identity.outputs.user_id }}+${{ steps.release-bot.outputs.app-slug }}[bot]@users.noreply.github.com
+
+  recover_release:
+    if: github.event_name == 'workflow_dispatch'
+    name: Recover Swift SDK release
+    needs:
+      - validate_recovery
+      - verify
+    runs-on: macos-latest
+    timeout-minutes: 30
+    concurrency:
+      group: release-${{ github.repository }}-main
+      cancel-in-progress: false
+    environment:
+      name: release
+      deployment: false
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.sha }}
+
+      - name: Select latest stable Xcode
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1
+        with:
+          ruby-version: .ruby-version
+
+      - name: Install release dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          bundle config set --local path vendor/bundle
+          bundle install --jobs 4 --retry 3
+
+      - name: Publish missing CocoaPods version
+        shell: bash
+        env:
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+          VERSION: ${{ needs.validate_recovery.outputs.version }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$COCOAPODS_TRUNK_TOKEN" ]]; then
+            echo "COCOAPODS_TRUNK_TOKEN is required for release recovery" >&2
+            exit 1
+          fi
+          ./scripts/publish-cocoapods.sh "$VERSION"
+
+      - name: Create release bot token
+        id: release-bot
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          client-id: ${{ vars.PUTIO_RELEASE_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.PUTIO_RELEASE_BOT_PRIVATE_KEY }}
+          permission-contents: write
+
+      - name: Create missing GitHub Release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.release-bot.outputs.token }}
+          TAG: ${{ needs.validate_recovery.outputs.tag }}
+        run: |
+          set -euo pipefail
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "$TAG already has a GitHub Release"
+            exit 0
+          fi
+
+          notes_file="$RUNNER_TEMP/release-notes.md"
+          git show --no-patch --format=%B "$TAG" | tail -n +3 > "$notes_file"
+          if [[ ! -s "$notes_file" ]]; then
+            echo "$TAG has no release notes in its commit message" >&2
+            exit 1
+          fi
+          gh release create "$TAG" --verify-tag --title "$TAG" --notes-file "$notes_file"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,16 @@ jobs:
             exit 1
           fi
 
+          tag_commit="$(git rev-parse "refs/tags/${tag}^{commit}")"
+          if ! git merge-base --is-ancestor "$tag_commit" "$GITHUB_SHA"; then
+            echo "$tag is not an ancestor of recovery main $GITHUB_SHA" >&2
+            exit 1
+          fi
+          if ! git diff --quiet "$tag_commit" "$GITHUB_SHA" -- LICENSE PutioSDK podspec_helper.rb; then
+            echo "CocoaPods source payload changed after $tag; recovery requires a new release" >&2
+            exit 1
+          fi
+
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
@@ -268,6 +278,7 @@ jobs:
         run: |
           set -euo pipefail
           bundle config set --local path vendor/bundle
+          bundle config set --local frozen true
           bundle install --jobs 4 --retry 3
 
       - name: Publish missing CocoaPods version
@@ -304,7 +315,7 @@ jobs:
           fi
 
           notes_file="$RUNNER_TEMP/release-notes.md"
-          git show --no-patch --format=%B "$TAG" | tail -n +3 > "$notes_file"
+          git log -1 --format=%b "${TAG}^{commit}" > "$notes_file"
           if [[ ! -s "$notes_file" ]]; then
             echo "$TAG has no release notes in its commit message" >&2
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,9 @@ jobs:
             echo "$tag is not an ancestor of recovery main $GITHUB_SHA" >&2
             exit 1
           fi
+
+          # Recovery publishes the repaired podspec from main against the
+          # immutable tagged sources. Only delivery metadata may differ.
           if ! git diff --quiet "$tag_commit" "$GITHUB_SHA" -- LICENSE PutioSDK podspec_helper.rb; then
             echo "CocoaPods source payload changed after $tag; recovery requires a new release" >&2
             exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,7 @@ make print-simulator-destination
 - If semantic-release creates a version commit and tag before publishing fails, fix the cause on `main`, then dispatch `CI` from `main` with that exact `recover_version`
 - Release recovery validates `main`, `VERSION`, and the existing tag before loading release secrets; it idempotently publishes the missing CocoaPods version before creating the missing GitHub Release
 - Recovery requires `VERSION` to remain unchanged and the tagged CocoaPods source payload (`LICENSE`, `PutioSDK/`, and `podspec_helper.rb`) to match `main`; source changes require a new release instead
+- Keep the protected `release` Environment deployment policy restricted to the `main` branch; the workflow guard is defense in depth, not the secret boundary
 
 ## Pull Requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,8 @@ make print-simulator-destination
 - CocoaPods publishing additionally needs `COCOAPODS_TRUNK_TOKEN` in the protected `release` Environment
 - The `release` Environment is a publish-secret boundary, so the release job sets `deployment: false`
 - Release jobs cache CocoaPods download artifacts only and regenerate generated `Example/Pods`
+- If semantic-release creates a version commit and tag before publishing fails, fix the cause on `main`, then dispatch `CI` from `main` with that exact `recover_version`
+- Release recovery validates `main`, `VERSION`, and the existing tag before loading release secrets; it idempotently publishes the missing CocoaPods version before creating the missing GitHub Release
 
 ## Pull Requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,7 @@ make print-simulator-destination
 - Release jobs cache CocoaPods download artifacts only and regenerate generated `Example/Pods`
 - If semantic-release creates a version commit and tag before publishing fails, fix the cause on `main`, then dispatch `CI` from `main` with that exact `recover_version`
 - Release recovery validates `main`, `VERSION`, and the existing tag before loading release secrets; it idempotently publishes the missing CocoaPods version before creating the missing GitHub Release
+- Recovery requires `VERSION` to remain unchanged and the tagged CocoaPods source payload (`LICENSE`, `PutioSDK/`, and `podspec_helper.rb`) to match `main`; source changes require a new release instead
 
 ## Pull Requests
 

--- a/PutioSDK.podspec
+++ b/PutioSDK.podspec
@@ -1,5 +1,7 @@
-require_relative 'podspec_helper'
+podspec_helper_path = File.expand_path('podspec_helper.rb', __dir__)
+podspec_helper = Module.new
+podspec_helper.module_eval(File.read(podspec_helper_path), podspec_helper_path)
 
 Pod::Spec.new do |s|
-  PutioSDKPodspec.configure(s, name: 'PutioSDK', module_name: 'PutioSDK')
+  podspec_helper::PutioSDKPodspec.configure(s, name: 'PutioSDK', module_name: 'PutioSDK')
 end

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -9,7 +9,7 @@ make verify-concurrency
 make live-test
 ```
 
-`make verify` is the deterministic repo gate. It lints formatting with the Xcode toolchain's `swift format` (stock rules), verifies that CocoaPods package pruning keeps the podspec's support files, runs the Swift package tests (including the strict-concurrency consumer proof) with coverage enabled, enforces a `90%` source line coverage floor across `PutioSDK/Classes`, then builds the package and the example-backed CocoaPods workspace.
+`make verify` is the deterministic repo gate. It lints formatting with the Xcode toolchain's `swift format` (stock rules), verifies that CocoaPods package pruning keeps the podspec's support files and that temporary podspec evaluation cannot replace the active helper, runs the Swift package tests (including the strict-concurrency consumer proof) with coverage enabled, enforces a `90%` source line coverage floor across `PutioSDK/Classes`, then builds the package and the example-backed CocoaPods workspace.
 
 `make verify-platforms` runs the deterministic suite on tvOS and watchOS simulators through the `PlatformVerify.xcworkspace` wrapper (the tracked CocoaPods `_Pods.xcodeproj` symlink breaks xcodebuild package discovery at the repository root). The URLProtocol-backed transport tests skip on watchOS with a documented reason: watchOS proxies `URLSession` loads out of process and never consults custom `URLProtocol` classes. Pure-logic suites run on every platform.
 
@@ -22,7 +22,7 @@ for why and for the full strict-concurrency contract.
 ## Verification Shape
 
 - `make verify` first runs `swift format lint --strict` with stock rules over the package, tests, example app, and scripts
-- `make verify` runs `scripts/check-podspec-package.rb` through Bundler to ensure CocoaPods package pruning keeps `VERSION` and `podspec_helper.rb`
+- `make verify` runs `scripts/check-podspec-package.rb` through Bundler to ensure CocoaPods package pruning keeps `VERSION` and `podspec_helper.rb` without leaking a downloaded helper into later platform validation
 - `make verify` runs `./scripts/check-sendable-audit.sh` to keep the strict-concurrency `Sendable` audit list exhaustive
 - `make verify` runs package-level SwiftPM tests, including `PutioSDKTests` and `PutioSDKStrictConcurrencyTests` in one combined `swift test` invocation
 - `make verify` fails if source line coverage for `PutioSDK/Classes` drops below `90%`

--- a/scripts/check-podspec-package.rb
+++ b/scripts/check-podspec-package.rb
@@ -18,15 +18,20 @@ Dir.mktmpdir('putio-sdk-pod-package-') do |temporary_directory|
     FileUtils.cp_r(File.join(repository_root, path), package_root)
   end
 
+  expected_version = File.read(File.join(repository_root, 'VERSION')).strip
   spec = Pod::Specification.from_file(File.join(package_root, 'PutioSDK.podspec'))
+  abort 'Packaged podspec leaked PutioSDKPodspec into the global namespace' if Object.const_defined?(:PutioSDKPodspec, false)
   specs_by_platform = spec.available_platforms.to_h { |platform| [platform, [spec]] }
   Pod::Sandbox::PodDirCleaner.new(Pathname(package_root), specs_by_platform).clean!
 
   missing_files = required_support_files.reject { |path| File.file?(File.join(package_root, path)) }
   abort "CocoaPods package pruning removed: #{missing_files.join(', ')}" unless missing_files.empty?
 
-  expected_version = File.read(File.join(repository_root, 'VERSION')).strip
-  packaged_version = spec.version.to_s
+  packaged_helper_path = File.join(package_root, 'podspec_helper.rb')
+  packaged_helper = Module.new
+  packaged_helper.module_eval(File.read(packaged_helper_path), packaged_helper_path)
+  abort 'Pruned helper leaked PutioSDKPodspec into the global namespace' if Object.const_defined?(:PutioSDKPodspec, false)
+  packaged_version = packaged_helper::PutioSDKPodspec.version
   abort "Packaged podspec version #{packaged_version.inspect} does not match #{expected_version.inspect}" unless packaged_version == expected_version
 
   # CocoaPods evaluates the downloaded podspec while validating iOS, removes its
@@ -36,6 +41,9 @@ Dir.mktmpdir('putio-sdk-pod-package-') do |temporary_directory|
 
   reloaded_spec = Pod::Specification.from_file(File.join(repository_root, 'PutioSDK.podspec'))
   abort "Reloaded podspec version #{reloaded_spec.version} does not match #{expected_version}" unless reloaded_spec.version.to_s == expected_version
+  abort 'Reloaded podspec leaked PutioSDKPodspec into the global namespace' if Object.const_defined?(:PutioSDKPodspec, false)
+  expected_source = { :git => 'https://github.com/putdotio/putio-sdk-swift.git', :tag => "v#{expected_version}" }
+  abort "Reloaded podspec source #{reloaded_spec.source.inspect} does not match #{expected_source.inspect}" unless reloaded_spec.source == expected_source
 
   puts "CocoaPods package support files preserved for PutioSDK #{packaged_version}"
 end

--- a/scripts/check-podspec-package.rb
+++ b/scripts/check-podspec-package.rb
@@ -25,14 +25,14 @@ Dir.mktmpdir('putio-sdk-pod-package-') do |temporary_directory|
   missing_files = required_support_files.reject { |path| File.file?(File.join(package_root, path)) }
   abort "CocoaPods package pruning removed: #{missing_files.join(', ')}" unless missing_files.empty?
 
-  load File.join(package_root, 'podspec_helper.rb')
-  packaged_version = PutioSDKPodspec.version
   expected_version = File.read(File.join(repository_root, 'VERSION')).strip
+  packaged_version = spec.version.to_s
   abort "Packaged podspec version #{packaged_version.inspect} does not match #{expected_version.inspect}" unless packaged_version == expected_version
 
-  def configure_putio_sdk_spec(...)
-    raise 'A downloaded podspec replaced the active podspec helper'
-  end
+  # CocoaPods evaluates the downloaded podspec while validating iOS, removes its
+  # temporary source directory, then evaluates the original podspec for tvOS and
+  # watchOS. The downloaded helper must not replace the original helper module.
+  FileUtils.rm_rf(package_root)
 
   reloaded_spec = Pod::Specification.from_file(File.join(repository_root, 'PutioSDK.podspec'))
   abort "Reloaded podspec version #{reloaded_spec.version} does not match #{expected_version}" unless reloaded_spec.version.to_s == expected_version

--- a/scripts/check-podspec-package.rb
+++ b/scripts/check-podspec-package.rb
@@ -33,7 +33,6 @@ Dir.mktmpdir('putio-sdk-pod-package-') do |temporary_directory|
   # temporary source directory, then evaluates the original podspec for tvOS and
   # watchOS. The downloaded helper must not replace the original helper module.
   FileUtils.remove_entry(package_root)
-  abort "Temporary package still exists after removal" if Dir.exist?(package_root)
 
   reloaded_spec = Pod::Specification.from_file(File.join(repository_root, 'PutioSDK.podspec'))
   abort "Reloaded podspec version #{reloaded_spec.version} does not match #{expected_version}" unless reloaded_spec.version.to_s == expected_version

--- a/scripts/check-podspec-package.rb
+++ b/scripts/check-podspec-package.rb
@@ -32,7 +32,8 @@ Dir.mktmpdir('putio-sdk-pod-package-') do |temporary_directory|
   # CocoaPods evaluates the downloaded podspec while validating iOS, removes its
   # temporary source directory, then evaluates the original podspec for tvOS and
   # watchOS. The downloaded helper must not replace the original helper module.
-  FileUtils.rm_rf(package_root)
+  FileUtils.remove_entry(package_root)
+  abort "Temporary package still exists after removal" if Dir.exist?(package_root)
 
   reloaded_spec = Pod::Specification.from_file(File.join(repository_root, 'PutioSDK.podspec'))
   abort "Reloaded podspec version #{reloaded_spec.version} does not match #{expected_version}" unless reloaded_spec.version.to_s == expected_version


### PR DESCRIPTION
## Summary

CocoaPods re-evaluates the active podspec for each platform. During `pod spec lint`, the downloaded tag's helper replaced the active helper, then CocoaPods deleted that temporary source directory; tvOS failed when the replacement tried to reopen its missing `VERSION`

Load each podspec helper in an isolated module, cover namespace isolation and the post-prune helper path, and add a fail-closed recovery dispatch for a version whose tag exists but whose CocoaPods package or GitHub Release is missing

Recovery stays on `main`, validates `VERSION`, the immutable tag, and the tagged source payload before loading release secrets, uses the repository's frozen bootstrap path, publishes CocoaPods idempotently, then creates the GitHub Release through `putio-releaser`. Push and dispatch verification use separate concurrency groups so recovery cannot cancel release verification

## Validation

- [x] `make verify` — 52 tests, 91.09% source coverage, Swift package build, CocoaPods example build
- [x] `make verify-platforms`
- [x] `actionlint .github/workflows/ci.yml`
- [x] CocoaPods package regression covers helper namespace isolation, post-prune evaluation, and podspec source/tag alignment
- [ ] `make live-test` when API behavior needs real backend evidence — not needed; no API behavior changed

Fresh CocoaPods home, against the existing remote `v3.4.1` source tag:

```text
before: [tvOS] No such file or directory .../VERSION
after:  PutioSDK.podspec passed validation (iOS, tvOS, watchOS)
```

## SDK Contract

- [x] Public API changes are intentional and documented — no public API changes
- [x] Request and response models are typed at the boundary — unchanged
- [x] Error behavior includes useful recovery or retry guidance when applicable — unchanged

## Risk

This changes release automation. Recovery is unavailable from non-`main` refs, rejects non-stable versions, requires current `VERSION`, the existing tag, and the tagged release payload to match, installs frozen dependencies, and runs only after normal verification

The protected `release` Environment currently restricts deployments to `main`; the workflow guard is defense in depth

Current partial state: `v3.4.1` exists at `1f17dc4`, while CocoaPods `3.4.1` and the GitHub Release are absent. After this PR merges, dispatch `CI` from `main` with `recover_version=3.4.1`; do not rerun the failed semantic-release job
