### PR TITLE
feat(files): model absent next file

### DIFF
--- a/PutioSDK/Classes/Files/FilesAPI.swift
+++ b/PutioSDK/Classes/Files/FilesAPI.swift
@@ -64,7 +64,16 @@ extension PutioSDK {
     let envelope = try await request(
       "/files/\(fileID)/next-file", query: ["file_type": .string(fileType.rawValue)],
       as: PutioNextFileEnvelope.self)
-    return envelope.nextFile
+    return envelope.nextFile.makeNextFile(type: fileType)
+  }
+
+  public func findNextFileIfAvailable(fileID: Int, fileType: PutioNextFileType) async throws
+    -> PutioNextFile?
+  {
+    let envelope = try await request(
+      "/files/\(fileID)/next-file", query: ["file_type": .string(fileType.rawValue)],
+      as: PutioOptionalNextFileEnvelope.self)
+    return envelope.nextFile?.makeNextFile(type: fileType)
   }
 
   public func setSortBy(fileId: Int, sortBy: String) async throws -> PutioOKResponse {
@@ -116,9 +125,45 @@ public struct PutioFilesMoveResponse: Codable, Sendable {
 }
 
 private struct PutioNextFileEnvelope: Decodable {
-  let nextFile: PutioNextFile
+  let nextFile: PutioNextFilePayload
 
   enum CodingKeys: String, CodingKey {
     case nextFile = "next_file"
+  }
+}
+
+private struct PutioOptionalNextFileEnvelope: Decodable {
+  let nextFile: PutioNextFilePayload?
+
+  enum CodingKeys: String, CodingKey {
+    case nextFile = "next_file"
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    nextFile = try container.decode(PutioNextFilePayload?.self, forKey: .nextFile)
+  }
+}
+
+private struct PutioNextFilePayload: Decodable {
+  let id: Int
+  let name: String
+  let parentID: Int
+
+  enum CodingKeys: String, CodingKey {
+    case id
+    case name
+    case parentID = "parent_id"
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    id = try container.decode(Int.self, forKey: .id)
+    name = try container.decode(String.self, forKey: .name)
+    parentID = try container.decodeIfPresent(Int.self, forKey: .parentID) ?? 0
+  }
+
+  func makeNextFile(type: PutioNextFileType) -> PutioNextFile {
+    PutioNextFile(id: id, name: name, parentID: parentID, type: type)
   }
 }

--- a/PutioSDK/Classes/Files/FilesModel.swift
+++ b/PutioSDK/Classes/Files/FilesModel.swift
@@ -323,6 +323,13 @@ open class PutioNextFile: Decodable {
     case type = "file_type"
   }
 
+  init(id: Int, name: String, parentID: Int, type: PutioNextFileType) {
+    self.id = id
+    self.name = name
+    self.parentID = parentID
+    self.type = type
+  }
+
   public required init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     self.id = try container.decode(Int.self, forKey: .id)

--- a/Tests/PutioSDKStrictConcurrencyTests/PutioSDKStrictConcurrencyTests.swift
+++ b/Tests/PutioSDKStrictConcurrencyTests/PutioSDKStrictConcurrencyTests.swift
@@ -90,6 +90,7 @@ private func auditAsyncConsumerSurface(_ sdk: PutioSDK) async throws {
   _ = try await sdk.getFiles(parentID: 0)
   _ = try await sdk.getFile(fileID: 1)
   _ = try await sdk.findNextFile(fileID: 1, fileType: .video)
+  _ = try await sdk.findNextFileIfAvailable(fileID: 1, fileType: .video)
   _ = try await sdk.resolveVideoPlaybackSource(fileID: 1)
   _ = try await sdk.getMp4ConversionStatus(fileID: 1)
   _ = try await sdk.getGrants()

--- a/Tests/PutioSDKTests/PutioSDKFilesTests.swift
+++ b/Tests/PutioSDKTests/PutioSDKFilesTests.swift
@@ -8,6 +8,66 @@ final class PutioSDKFilesTests: XCTestCase {
     super.tearDown()
   }
 
+  func testOptionalNextFileMapsSuccessorAndAbsence() async throws {
+    try skipUnlessURLProtocolMockingIsSupported()
+    var responses = [
+      """
+      {
+        "next_file": {
+          "id": 43,
+          "name": "Episode 2.mkv",
+          "parent_id": 7
+        }
+      }
+      """,
+      #"{"next_file":null}"#,
+    ]
+    MockURLProtocol.requestHandler = { request in
+      XCTAssertEqual(request.url?.path, "/v2/files/42/next-file")
+      let components = URLComponents(
+        url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false)
+      XCTAssertEqual(
+        components?.queryItems?.first(where: { $0.name == "file_type" })?.value, "VIDEO")
+      return (makeHTTPResponse(for: request, statusCode: 200), Data(responses.removeFirst().utf8))
+    }
+
+    let sdk = PutioSDK(
+      config: PutioSDKConfig(clientID: "ios-app", token: "token-123"),
+      urlSession: makeTestSession()
+    )
+
+    let successor = try await sdk.findNextFileIfAvailable(fileID: 42, fileType: .video)
+    let absent = try await sdk.findNextFileIfAvailable(fileID: 42, fileType: .video)
+
+    XCTAssertEqual(successor?.id, 43)
+    XCTAssertEqual(successor?.name, "Episode 2.mkv")
+    XCTAssertEqual(successor?.parentID, 7)
+    XCTAssertEqual(successor?.type, .video)
+    XCTAssertNil(absent)
+  }
+
+  func testOptionalNextFileRejectsMissingEnvelopeKey() async throws {
+    try skipUnlessURLProtocolMockingIsSupported()
+    MockURLProtocol.requestHandler = { request in
+      XCTAssertEqual(request.url?.path, "/v2/files/42/next-file")
+      return (makeHTTPResponse(for: request, statusCode: 200), Data(#"{}"#.utf8))
+    }
+
+    let sdk = PutioSDK(
+      config: PutioSDKConfig(clientID: "ios-app", token: "token-123"),
+      urlSession: makeTestSession()
+    )
+
+    do {
+      _ = try await sdk.findNextFileIfAvailable(fileID: 42, fileType: .video)
+      XCTFail("Expected a missing next_file key to fail decoding")
+    } catch let error as PutioSDKError {
+      XCTAssertTrue(error.isDecodingFailure)
+    } catch {
+      XCTFail("Expected PutioSDKError, got \(type(of: error))")
+    }
+  }
+
   func testFilesAndMediaEndpointsDecodeResponsesAndBuildExpectedRequests() async throws {
     try skipUnlessURLProtocolMockingIsSupported()
     MockURLProtocol.requestHandler = { request in
@@ -138,8 +198,7 @@ final class PutioSDKFilesTests: XCTestCase {
             "next_file": {
               "id": 43,
               "name": "Episode 2.mkv",
-              "parent_id": 7,
-              "file_type": "VIDEO"
+              "parent_id": 7
             }
           }
           """

--- a/Tests/PutioSDKTests/PutioSDKPublicSurfaceTests.swift
+++ b/Tests/PutioSDKTests/PutioSDKPublicSurfaceTests.swift
@@ -86,6 +86,27 @@ final class PutioSDKPublicSurfaceTests: XCTestCase {
     XCTAssertEqual(source.startFrom, 37)
     XCTAssertEqual(source.url.path, "/v2/files/42/hls/media.m3u8")
   }
+
+  func testOptionalNextFileIsAvailableToPackageConsumers() async throws {
+    try skipUnlessURLProtocolMockingIsSupported()
+    MockURLProtocol.requestHandler = { request in
+      XCTAssertEqual(request.url?.path, "/v2/files/42/next-file")
+      return (
+        makeHTTPResponse(for: request, statusCode: 200),
+        Data(#"{"next_file":null}"#.utf8)
+      )
+    }
+
+    let sdk = PutioSDK(
+      config: PutioSDKConfig(clientID: "ios-app", token: "token-123"),
+      urlSession: makeTestSession()
+    )
+
+    let nextFile: PutioNextFile? =
+      try await sdk.findNextFileIfAvailable(fileID: 42, fileType: .video)
+
+    XCTAssertNil(nextFile)
+  }
 }
 
 private func dumpOutput<T>(_ value: T) -> String {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -137,6 +137,7 @@ language mode 5.
   - `moveFiles`
   - `renameFile`
   - `findNextFile`
+  - `findNextFileIfAvailable` for a normal `next_file: null` response
   - `setFileSort`
   - `resetFileSort`
   - `getStartFrom`


### PR DESCRIPTION
## Summary

What changed, and why?

## Validation

- [ ] `make verify`
- [ ] `make live-test` when API behavior needs real backend evidence
- [ ] Example app smoke when auth, package installation, or request flow changes

## SDK Contract

- [ ] Public API changes are intentional and documented
- [ ] Request and response models are typed at the boundary
- [ ] Error behavior includes useful recovery or retry guidance when applicable

## Risk

Call out migrations, release-flow changes, auth changes, or follow-up work.