### PR TITLE
chore(scripts): accept lowercase simulator UDIDs

### DIFF
--- a/scripts/platform-simulator-destination.sh
+++ b/scripts/platform-simulator-destination.sh
@@ -16,7 +16,7 @@ esac
 udid="$(
   xcrun simctl list devices available \
     | grep -F "${family}" \
-    | grep -oE '[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}' \
+    | grep -oE '[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}' \
     | head -n 1
 )"
 


### PR DESCRIPTION
## Problem

`scripts/platform-simulator-destination.sh` matched only uppercase hex in simulator UDIDs. `simctl` prints uppercase today, but nothing guarantees it, and a case change would make `make verify-platforms` report a missing runtime.

## Solution

Match either case in the UDID pattern. Verified locally: the script still resolves both the watchOS and tvOS destinations, and a synthetic lowercase UDID now matches.

Closes the remaining unresolved Copilot thread from #47.