### PR TITLE
perf(files): skip duplicate date parsing for ordinary files

### DIFF
--- a/PutioSDK/Classes/Files/FilesModel.swift
+++ b/PutioSDK/Classes/Files/FilesModel.swift
@@ -140,9 +140,10 @@ open class PutioFile: PutioBaseFile {
     self.isShared = try container.decodeIfPresent(Bool.self, forKey: .isShared) ?? false
 
     let id = try baseContainer.decode(Int.self, forKey: .id)
-    let createdAt = try PutioSDKDateParser.decodeDate(forKey: .createdAt, from: baseContainer)
+    let createdAt =
+      id == 0 ? try PutioSDKDateParser.decodeDate(forKey: .createdAt, from: baseContainer) : nil
     let updatedAt = try container.decodeIfPresent(String.self, forKey: .updatedAt)
-    self.updatedAt = try PutioSDKDateParser.parse(updatedAt, fallback: id == 0 ? createdAt : nil)
+    self.updatedAt = try PutioSDKDateParser.parse(updatedAt, fallback: createdAt)
 
     let folderType = try container.decodeIfPresent(String.self, forKey: .folderType) ?? ""
     self.isSharedRoot = folderType == "SHARED_ROOT"

--- a/Tests/PutioSDKTests/PutioSDKFilesTests.swift
+++ b/Tests/PutioSDKTests/PutioSDKFilesTests.swift
@@ -731,10 +731,35 @@ final class PutioSDKFilesTests: XCTestCase {
     XCTAssertEqual(metadata.aspectRatio, 0)
     XCTAssertEqual(rootFile.id, 0)
     XCTAssertEqual(rootFile.updatedAt, rootFile.createdAt)
-    XCTAssertNoThrow(try PutioSDKDateParser.parse("2026-04-23T19:08:48.356333"))
-    XCTAssertNoThrow(try PutioSDKDateParser.parse("2026-04-23T19:08:48.356333Z"))
+    for value in ["2026-04-23T19:08:48.356333", "2026-04-23T19:08:48.356333Z"] {
+      XCTAssertEqual(
+        try PutioSDKDateParser.parse(value).timeIntervalSince1970, 1_776_971_328.356333,
+        accuracy: 0.001)
+    }
     XCTAssertThrowsError(try PutioSDKDateParser.parse(nil))
     XCTAssertThrowsError(try PutioSDKDateParser.parse("not-a-date"))
+  }
+
+  func testFileDatesDecodeIndependentlyAndRejectInvalidCreationDates() throws {
+    let decoder = JSONDecoder()
+    for id in [0, 42] {
+      for createdAt in ["2026-04-23T19:08:48Z", "2026-04-23T19:08:48.356333"] {
+        let data = Data(
+          """
+          {"id": \(id), "name": "file", "file_type": "VIDEO",
+           "created_at": "\(createdAt)", "updated_at": "2026-04-24T19:08:48Z"}
+          """.utf8)
+        let file = try decoder.decode(PutioFile.self, from: data)
+        XCTAssertEqual(file.createdAt, try PutioSDKDateParser.parse(createdAt))
+        XCTAssertEqual(file.updatedAt.timeIntervalSince1970, 1_777_057_728)
+      }
+      let invalid = Data(
+        """
+        {"id": \(id), "name": "file", "file_type": "VIDEO",
+         "created_at": "not-a-date", "updated_at": "2026-04-24T19:08:48Z"}
+        """.utf8)
+      XCTAssertThrowsError(try decoder.decode(PutioFile.self, from: invalid))
+    }
   }
 
   func testTypedFileInputsBuildExpectedParameters() {


### PR DESCRIPTION
## Summary

Ordinary `PutioFile` decoding parsed `created_at` twice. Decode it in the base model once; keep the root folder's predecode for its `updated_at` fallback.

The release-build benchmark decoded 1,000 files per sample, with 2 warmups and 7 measured samples per timestamp format. A repeated before/after comparison measured:

| Dates | Before median | After median |
| --- | ---: | ---: |
| UTC | 1,323 ms | 862 ms |
| Fractional, without timezone | 6,611 ms | 3,045 ms |

Host load makes these timings variable. The fixed reduction is three date parses to two per ordinary file.

## Validation

- [x] `make verify`: 67 tests, 91.43% source coverage, Swift Package and CocoaPods builds passed
- [x] 15 focused file tests; exact fractional timestamps, independent creation/update dates, malformed creation-date rejection, and existing root fallback coverage
- [x] Slopguard: Codex `gpt-5.6-sol`, high reasoning, zero findings at `1379bd5`
- Live API and auth smoke are not applicable to this local decode change

## SDK Contract

- Public API and accepted date formats are unchanged
- Root fallback and required creation-date validation remain intact

## Risk

When multiple fields are malformed, the first reported decoding error can change. Each invalid date still rejects the model.
