### PR TITLE
test: prove transport isolation and device-code cancellation contracts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: bootstrap verify verify-concurrency verify-spm verify-platforms coverage-check podspec-package-check sendable-audit simulator-destination-check live-test example-install print-simulator-destination secrets-setup secrets-clean clean
+.PHONY: bootstrap verify verify-concurrency verify-spm verify-platforms coverage-check podspec-package-check sendable-audit transport-isolation-check simulator-destination-check live-test example-install print-simulator-destination secrets-setup secrets-clean clean
 
 bootstrap:
 	bundle config set --local path vendor/bundle
@@ -8,6 +8,7 @@ verify:
 	swift format lint --strict --recursive --parallel Package.swift PutioSDK Tests Example/PutioSDK Example/Tests scripts
 	bundle exec ruby scripts/check-podspec-package.rb
 	./scripts/check-sendable-audit.sh
+	./scripts/check-transport-isolation.sh
 	./scripts/check-platform-simulator-destination.sh
 	swift test --enable-code-coverage --filter PutioSDKTests --filter PutioSDKStrictConcurrencyTests
 	./scripts/check-spm-coverage.sh 90
@@ -50,6 +51,9 @@ podspec-package-check:
 
 sendable-audit:
 	./scripts/check-sendable-audit.sh
+
+transport-isolation-check:
+	./scripts/check-transport-isolation.sh
 
 simulator-destination-check:
 	./scripts/check-platform-simulator-destination.sh

--- a/PutioSDK/Classes/Auth/AuthAPI.swift
+++ b/PutioSDK/Classes/Auth/AuthAPI.swift
@@ -184,11 +184,13 @@ extension PutioSDK {
         throw CancellationError()
       }
 
+      await deviceCodePollObserver?(.pollCompleted)
       try Task.checkCancellation()
       if let authorization {
         return authorization
       }
 
+      await deviceCodePollObserver?(.willSleep)
       try await Task.sleep(for: interval)
     }
   }
@@ -231,6 +233,13 @@ extension PutioSDK {
       "/two_factor/recovery_codes/refresh", method: .post, as: PutioRecoveryCodesEnvelope.self)
     return envelope.recoveryCodes
   }
+}
+
+// Boundaries of one `awaitDeviceCodeAuthorization` iteration, reported through the
+// internal `deviceCodePollObserver` seam.
+enum PutioDeviceCodePollEvent: Sendable {
+  case pollCompleted
+  case willSleep
 }
 
 private struct PutioOAuthTokenEnvelope: Decodable {

--- a/PutioSDK/Classes/Auth/AuthAPI.swift
+++ b/PutioSDK/Classes/Auth/AuthAPI.swift
@@ -191,7 +191,12 @@ extension PutioSDK {
       }
 
       await deviceCodePollObserver?(.willSleep)
-      try await deviceCodePollSleeper(interval)
+      if let deviceCodePollSleeper {
+        try await deviceCodePollSleeper(interval)
+      } else {
+        try await Self.sleepBetweenDeviceCodePolls(
+          interval, onEntry: deviceCodeSleepEntryObserver)
+      }
     }
   }
 

--- a/PutioSDK/Classes/Auth/AuthAPI.swift
+++ b/PutioSDK/Classes/Auth/AuthAPI.swift
@@ -191,7 +191,7 @@ extension PutioSDK {
       }
 
       await deviceCodePollObserver?(.willSleep)
-      try await Task.sleep(for: interval)
+      try await deviceCodePollSleeper(interval)
     }
   }
 

--- a/PutioSDK/Classes/Auth/AuthAPI.swift
+++ b/PutioSDK/Classes/Auth/AuthAPI.swift
@@ -191,12 +191,7 @@ extension PutioSDK {
       }
 
       await deviceCodePollObserver?(.willSleep)
-      if let deviceCodePollSleeper {
-        try await deviceCodePollSleeper(interval)
-      } else {
-        try await Self.sleepBetweenDeviceCodePolls(
-          interval, onEntry: deviceCodeSleepEntryObserver)
-      }
+      try await deviceCodePollClock.sleep(for: interval)
     }
   }
 

--- a/PutioSDK/Classes/PutioSDK.swift
+++ b/PutioSDK/Classes/PutioSDK.swift
@@ -56,7 +56,7 @@ public final class PutioSDK {
     )
     return try await perform(
       requestConfig: requestConfig,
-      delegate: PutioSDKDelegateReference(delegate, isExpectedFailure: isExpectedFailure),
+      delegateReference: PutioSDKDelegateReference(delegate, isExpectedFailure: isExpectedFailure),
       as: type)
   }
 
@@ -66,13 +66,15 @@ public final class PutioSDK {
   // consumer's main thread. `@concurrent` keeps that work on the global executor while the
   // public domain methods that call into `request` stay caller-isolated. Only the value
   // snapshot taken in `request` crosses the hop; `self.config` is never read here.
+  // scripts/check-transport-isolation.sh rejects `self.` member access and bare
+  // `config`/`delegate` reads inside every `@concurrent` body in this file.
   @concurrent
   private func perform<T: Decodable>(
     requestConfig: PutioSDKRequestConfig,
-    delegate: PutioSDKDelegateReference,
+    delegateReference: PutioSDKDelegateReference,
     as type: T.Type
   ) async throws -> sending T {
-    let data = try await execute(requestConfig: requestConfig, delegate: delegate)
+    let data = try await execute(requestConfig: requestConfig, delegateReference: delegateReference)
 
     do {
       return try JSONDecoder().decode(type, from: data)
@@ -80,7 +82,7 @@ public final class PutioSDK {
       let apiError = PutioSDKError(
         request: PutioSDKErrorRequestInformation(config: requestConfig), decodingError: error,
         responseBody: String(decoding: data, as: UTF8.self))
-      delegate.notify(apiError)
+      delegateReference.notify(apiError)
       throw apiError
     }
   }
@@ -88,9 +90,9 @@ public final class PutioSDK {
   // Stays off the caller's actor for the same reason as `request` above: keeps the
   // network round trip and error-envelope decode/delegate callback on the global executor.
   @concurrent
-  private func execute(requestConfig: PutioSDKRequestConfig, delegate: PutioSDKDelegateReference)
-    async throws -> Data
-  {
+  private func execute(
+    requestConfig: PutioSDKRequestConfig, delegateReference: PutioSDKDelegateReference
+  ) async throws -> Data {
     let requestInformation = PutioSDKErrorRequestInformation(config: requestConfig)
     let urlRequest = try buildURLRequest(from: requestConfig)
 
@@ -101,14 +103,14 @@ public final class PutioSDK {
       (data, response) = try await urlSession.data(for: urlRequest)
     } catch {
       let apiError = PutioSDKError(request: requestInformation, error: error)
-      delegate.notify(apiError)
+      delegateReference.notify(apiError)
       throw apiError
     }
 
     guard let httpResponse = response as? HTTPURLResponse else {
       let apiError = PutioSDKError(
         request: requestInformation, unknownError: URLError(.badServerResponse))
-      delegate.notify(apiError)
+      delegateReference.notify(apiError)
       throw apiError
     }
 
@@ -124,7 +126,7 @@ public final class PutioSDK {
         underlyingError: URLError(.badServerResponse),
         responseBody: body
       )
-      delegate.notify(apiError)
+      delegateReference.notify(apiError)
       throw apiError
     }
 

--- a/PutioSDK/Classes/PutioSDK.swift
+++ b/PutioSDK/Classes/PutioSDK.swift
@@ -18,7 +18,13 @@ public final class PutioSDK {
   // interrupted. Never set outside the package test targets.
   var deviceCodePollObserver: (@Sendable (PutioDeviceCodePollEvent) async -> Void)?
   var deviceCodePollSleeper: @Sendable (Duration) async throws -> Void = {
-    try await Task.sleep(for: $0)
+    try await PutioSDK.sleepBetweenDeviceCodePolls($0)
+  }
+
+  // The production interval sleep. Kept as a named entry point so tests can wrap it,
+  // observe entry, and prove the real primitive honours cancellation.
+  static func sleepBetweenDeviceCodePolls(_ interval: Duration) async throws {
+    try await Task.sleep(for: interval)
   }
 
   public convenience init(config: PutioSDKConfig) {

--- a/PutioSDK/Classes/PutioSDK.swift
+++ b/PutioSDK/Classes/PutioSDK.swift
@@ -13,17 +13,21 @@ public final class PutioSDK {
   public var config: PutioSDKConfig
 
   // Internal test seams for `awaitDeviceCodeAuthorization`. The observer is awaited at
-  // the loop's observable boundaries so tests can park it and cancel at an exact point;
-  // the sleeper replaces `Task.sleep` so a test clock can prove an active sleep is
-  // interrupted. Never set outside the package test targets.
+  // the loop's observable boundaries so tests can park it and cancel at an exact point.
+  // A sleeper replaces the interval sleep entirely; the entry observer is instead
+  // invoked synchronously by the production sleep primitive right before it suspends,
+  // so tests can prove the shipped sleep honours cancellation. Never set outside the
+  // package test targets.
   var deviceCodePollObserver: (@Sendable (PutioDeviceCodePollEvent) async -> Void)?
-  var deviceCodePollSleeper: @Sendable (Duration) async throws -> Void = {
-    try await PutioSDK.sleepBetweenDeviceCodePolls($0)
-  }
+  var deviceCodePollSleeper: (@Sendable (Duration) async throws -> Void)?
+  var deviceCodeSleepEntryObserver: (@Sendable () -> Void)?
 
-  // The production interval sleep. Kept as a named entry point so tests can wrap it,
-  // observe entry, and prove the real primitive honours cancellation.
-  static func sleepBetweenDeviceCodePolls(_ interval: Duration) async throws {
+  // The production interval sleep. `onEntry` runs synchronously immediately before the
+  // suspension, with no suspension point in between.
+  static func sleepBetweenDeviceCodePolls(
+    _ interval: Duration, onEntry: (@Sendable () -> Void)? = nil
+  ) async throws {
+    onEntry?()
     try await Task.sleep(for: interval)
   }
 

--- a/PutioSDK/Classes/PutioSDK.swift
+++ b/PutioSDK/Classes/PutioSDK.swift
@@ -81,7 +81,7 @@ public final class PutioSDK {
   // consumer's main thread. `@concurrent` keeps that work on the global executor while the
   // public domain methods that call into `request` stay caller-isolated. Only the value
   // snapshot taken in `request` crosses the hop; `self.config` is never read here.
-  // scripts/check-transport-isolation.sh rejects `self.` member access and bare
+  // scripts/check-transport-isolation.sh rejects any `self` use and bare
   // `config`/`delegate` reads inside every `@concurrent` body in this file.
   @concurrent
   private func perform<T: Decodable>(

--- a/PutioSDK/Classes/PutioSDK.swift
+++ b/PutioSDK/Classes/PutioSDK.swift
@@ -14,22 +14,11 @@ public final class PutioSDK {
 
   // Internal test seams for `awaitDeviceCodeAuthorization`. The observer is awaited at
   // the loop's observable boundaries so tests can park it and cancel at an exact point.
-  // A sleeper replaces the interval sleep entirely; the entry observer is instead
-  // invoked synchronously by the production sleep primitive right before it suspends,
-  // so tests can prove the shipped sleep honours cancellation. Never set outside the
-  // package test targets.
+  // The clock owns the interval sleep: the loop's only sleep is `clock.sleep`, so a test
+  // clock observes entry from inside the sleep and can prove cancellation lands while
+  // the sleep is active. Never set outside the package test targets.
   var deviceCodePollObserver: (@Sendable (PutioDeviceCodePollEvent) async -> Void)?
-  var deviceCodePollSleeper: (@Sendable (Duration) async throws -> Void)?
-  var deviceCodeSleepEntryObserver: (@Sendable () -> Void)?
-
-  // The production interval sleep. `onEntry` runs synchronously immediately before the
-  // suspension, with no suspension point in between.
-  static func sleepBetweenDeviceCodePolls(
-    _ interval: Duration, onEntry: (@Sendable () -> Void)? = nil
-  ) async throws {
-    onEntry?()
-    try await Task.sleep(for: interval)
-  }
+  var deviceCodePollClock: any Clock<Duration> = ContinuousClock()
 
   public convenience init(config: PutioSDKConfig) {
     self.init(config: config, urlSession: .shared)

--- a/PutioSDK/Classes/PutioSDK.swift
+++ b/PutioSDK/Classes/PutioSDK.swift
@@ -12,10 +12,14 @@ public final class PutioSDK {
 
   public var config: PutioSDKConfig
 
-  // Internal test seam: `awaitDeviceCodeAuthorization` awaits this at its observable
-  // boundaries so deterministic tests can park the loop and cancel at an exact point.
-  // Never set outside the package test targets.
+  // Internal test seams for `awaitDeviceCodeAuthorization`. The observer is awaited at
+  // the loop's observable boundaries so tests can park it and cancel at an exact point;
+  // the sleeper replaces `Task.sleep` so a test clock can prove an active sleep is
+  // interrupted. Never set outside the package test targets.
   var deviceCodePollObserver: (@Sendable (PutioDeviceCodePollEvent) async -> Void)?
+  var deviceCodePollSleeper: @Sendable (Duration) async throws -> Void = {
+    try await Task.sleep(for: $0)
+  }
 
   public convenience init(config: PutioSDKConfig) {
     self.init(config: config, urlSession: .shared)

--- a/PutioSDK/Classes/PutioSDK.swift
+++ b/PutioSDK/Classes/PutioSDK.swift
@@ -12,6 +12,11 @@ public final class PutioSDK {
 
   public var config: PutioSDKConfig
 
+  // Internal test seam: `awaitDeviceCodeAuthorization` awaits this at its observable
+  // boundaries so deterministic tests can park the loop and cancel at an exact point.
+  // Never set outside the package test targets.
+  var deviceCodePollObserver: (@Sendable (PutioDeviceCodePollEvent) async -> Void)?
+
   public convenience init(config: PutioSDKConfig) {
     self.init(config: config, urlSession: .shared)
   }

--- a/Tests/PutioSDKTests/PutioSDKAuthTests.swift
+++ b/Tests/PutioSDKTests/PutioSDKAuthTests.swift
@@ -355,24 +355,23 @@ final class PutioSDKAuthTests: XCTestCase {
     XCTAssertEqual(delegate.errors.map(\.statusCode), [500])
   }
 
-  func testAwaitDeviceCodeAuthorizationStopsWhenCancelled() async throws {
+  // Cancellation during the sleep between polls: the poll completes first (observed via
+  // URLSession task completion), the host gets time to enter its 60s sleep, and the
+  // elapsed bound proves the sleep itself was interrupted rather than waited out.
+  func testAwaitDeviceCodeAuthorizationStopsWhenCancelledDuringSleep() async throws {
     let counter = PollCounter()
     try installMockRequestHandler { request in
       _ = counter.increment()
       return (makeHTTPResponse(for: request, statusCode: 200), Data(#"{"oauth_token":null}"#.utf8))
     }
+    let observer = TaskCompletionObserver()
+    let host = DeviceCodePollingHost(urlSession: makeTestSession(taskObserver: observer))
 
-    let sdk = PutioSDK(
-      config: PutioSDKConfig(clientID: "ios-app", clientName: "put.io TV"),
-      urlSession: makeTestSession()
-    )
-
-    let task = Task {
-      try await sdk.awaitDeviceCodeAuthorization(code: "PENDING", pollInterval: .seconds(60))
-    }
-    while counter.value == 0 {
-      await Task.yield()
-    }
+    let clock = ContinuousClock()
+    let start = clock.now
+    let task = Task { try await host.poll(code: "PENDING", pollInterval: .seconds(60)) }
+    try observer.waitUntilTaskCompleted()
+    try await Task.sleep(for: .milliseconds(200))
     task.cancel()
 
     do {
@@ -381,34 +380,70 @@ final class PutioSDKAuthTests: XCTestCase {
     } catch is CancellationError {
     }
     XCTAssertEqual(counter.value, 1)
+    XCTAssertLessThan(clock.now - start, .seconds(5), "cancellation must interrupt the sleep")
   }
 
-  func testAwaitDeviceCodeAuthorizationDiscardsResultWhenCancelledMidPoll() async throws {
-    // The handler is installed before the polling task exists, and it looks the task up
-    // through a box, so the first request can never race a missing handler.
-    let pollingTask = TaskBox<PutioDeviceCodeAuthorization>()
+  // Cancellation after a poll has produced a result: the host actor is held busy while
+  // the request completes, so the resumption carrying `.authorized` stays queued behind
+  // the hold. Cancelling before releasing the hold guarantees the post-poll check runs
+  // on a cancelled task with a result already in hand. Removing that check would return
+  // `.authorized` here.
+  func testAwaitDeviceCodeAuthorizationDiscardsResultWhenCancelledAfterPollCompletes()
+    async throws
+  {
+    let gate = PollGate()
     try installMockRequestHandler { request in
-      // Cancel while the poll is producing a success, so the result is already in hand
-      // when the method reaches its post-poll cancellation check.
-      pollingTask.cancel()
+      gate.markRequestStarted()
+      try gate.waitUntilReleased()
       return (
         makeHTTPResponse(for: request, statusCode: 200), Data(#"{"oauth_token":"tv-token"}"#.utf8)
       )
     }
+    let observer = TaskCompletionObserver()
+    let host = DeviceCodePollingHost(urlSession: makeTestSession(taskObserver: observer))
 
-    let sdk = PutioSDK(
-      config: PutioSDKConfig(clientID: "ios-app", clientName: "put.io TV"),
-      urlSession: makeTestSession()
-    )
-    let task = pollingTask.start {
-      try await sdk.awaitDeviceCodeAuthorization(code: "READY", pollInterval: .seconds(60))
-    }
+    let task = Task { try await host.poll(code: "READY", pollInterval: .seconds(60)) }
+    try gate.waitUntilRequestStarted()
+
+    let hold = ActorHold()
+    Task { await host.hold(hold) }
+    try hold.waitUntilHeld()
+
+    gate.release()
+    try observer.waitUntilTaskCompleted()
+    task.cancel()
+    hold.release()
 
     do {
       let authorization = try await task.value
       XCTFail("Expected cancellation to win over \(authorization)")
     } catch is CancellationError {
     }
+  }
+
+  // A non-expiry failure reaches the delegate from the transport's global executor,
+  // not on the caller's actor.
+  @MainActor
+  func testAwaitDeviceCodeAuthorizationForwardsFailuresOffTheCallerActor() async throws {
+    try installMockRequestHandler { request in
+      (makeHTTPResponse(for: request, statusCode: 500), Data(#"{"status":"ERROR"}"#.utf8))
+    }
+
+    let sdk = PutioSDK(
+      config: PutioSDKConfig(clientID: "ios-app", clientName: "put.io TV"),
+      urlSession: makeTestSession()
+    )
+    let delegate = RecordingDelegate()
+    sdk.delegate = delegate
+
+    do {
+      _ = try await sdk.awaitDeviceCodeAuthorization(code: "BROKEN", pollInterval: .milliseconds(5))
+      XCTFail("Expected a server failure to propagate")
+    } catch let error as PutioSDKError {
+      XCTAssertEqual(error.statusCode, 500)
+    }
+    XCTAssertEqual(delegate.errors.map(\.statusCode), [500])
+    XCTAssertEqual(delegate.callbacksOnMainThread, [false])
   }
 
   func testAuthModelsDecodeGracefulDefaults() throws {
@@ -454,6 +489,7 @@ private final class PollCounter: @unchecked Sendable {
 private final class RecordingDelegate: PutioSDKDelegate, @unchecked Sendable {
   private let lock = NSLock()
   private var recorded: [PutioSDKError] = []
+  private var mainThreadFlags: [Bool] = []
 
   var errors: [PutioSDKError] {
     lock.lock()
@@ -461,33 +497,78 @@ private final class RecordingDelegate: PutioSDKDelegate, @unchecked Sendable {
     return recorded
   }
 
+  var callbacksOnMainThread: [Bool] {
+    lock.lock()
+    defer { lock.unlock() }
+    return mainThreadFlags
+  }
+
   func onPutioSDKError(error: PutioSDKError) {
     lock.lock()
     recorded.append(error)
+    mainThreadFlags.append(Thread.isMainThread)
     lock.unlock()
   }
 }
 
-private final class TaskBox<Success: Sendable>: @unchecked Sendable {
-  private let lock = NSLock()
-  private var task: Task<Success, Error>?
-  private var cancelRequested = false
+// Owns the SDK on an actor so `awaitDeviceCodeAuthorization` (caller-isolated under
+// NonisolatedNonsendingByDefault) resumes here after each poll; `hold` keeps the actor
+// busy so that resumption stays queued until the test releases it.
+private actor DeviceCodePollingHost {
+  private let sdk: PutioSDK
 
-  func start(_ operation: @escaping @Sendable () async throws -> Success) -> Task<Success, Error> {
-    lock.lock()
-    defer { lock.unlock() }
-    let task = Task(operation: operation)
-    self.task = task
-    if cancelRequested {
-      task.cancel()
+  init(urlSession: URLSession) {
+    sdk = PutioSDK(
+      config: PutioSDKConfig(clientID: "ios-app", clientName: "put.io TV"),
+      urlSession: urlSession)
+  }
+
+  func poll(code: String, pollInterval: Duration) async throws -> PutioDeviceCodeAuthorization {
+    try await sdk.awaitDeviceCodeAuthorization(code: code, pollInterval: pollInterval)
+  }
+
+  func hold(_ hold: ActorHold) {
+    hold.markHeld()
+    hold.waitUntilReleased()
+  }
+}
+
+private final class ActorHold: @unchecked Sendable {
+  private let held = DispatchSemaphore(value: 0)
+  private let released = DispatchSemaphore(value: 0)
+
+  func markHeld() { held.signal() }
+
+  func waitUntilHeld() throws {
+    guard held.wait(timeout: .now() + .seconds(5)) == .success else {
+      throw TestSynchronizationTimeout(stage: "actor hold")
     }
-    return task
   }
 
-  func cancel() {
-    lock.lock()
-    defer { lock.unlock() }
-    cancelRequested = true
-    task?.cancel()
+  func waitUntilReleased() {
+    _ = released.wait(timeout: .now() + .seconds(5))
   }
+
+  func release() { released.signal() }
+}
+
+private final class PollGate: @unchecked Sendable {
+  private let started = DispatchSemaphore(value: 0)
+  private let released = DispatchSemaphore(value: 0)
+
+  func markRequestStarted() { started.signal() }
+
+  func waitUntilRequestStarted() throws {
+    guard started.wait(timeout: .now() + .seconds(5)) == .success else {
+      throw TestSynchronizationTimeout(stage: "poll request start")
+    }
+  }
+
+  func waitUntilReleased() throws {
+    guard released.wait(timeout: .now() + .seconds(5)) == .success else {
+      throw TestSynchronizationTimeout(stage: "poll release")
+    }
+  }
+
+  func release() { released.signal() }
 }

--- a/Tests/PutioSDKTests/PutioSDKAuthTests.swift
+++ b/Tests/PutioSDKTests/PutioSDKAuthTests.swift
@@ -393,6 +393,50 @@ final class PutioSDKAuthTests: XCTestCase {
     XCTAssertLessThan(clock.now - start, .seconds(5), "cancellation must interrupt the sleep")
   }
 
+  // Same contract against the production sleeper. The observer parks at `.willSleep`,
+  // is released, and the SDK enters the real `Task.sleep` for a short interval before
+  // the test cancels. An uncancellable production sleeper would wait out the whole
+  // interval and trip the elapsed bound; a cancellable one returns almost immediately.
+  func testAwaitDeviceCodeAuthorizationProductionSleepIsInterruptedByCancellation()
+    async throws
+  {
+    let counter = PollCounter()
+    try installMockRequestHandler { request in
+      _ = counter.increment()
+      return (makeHTTPResponse(for: request, statusCode: 200), Data(#"{"oauth_token":null}"#.utf8))
+    }
+
+    let sdk = PutioSDK(
+      config: PutioSDKConfig(clientID: "ios-app", clientName: "put.io TV"),
+      urlSession: makeTestSession()
+    )
+    let barrier = PollBarrier()
+    sdk.deviceCodePollObserver = { event in
+      if event == .willSleep { await barrier.park() }
+    }
+
+    let interval = Duration.seconds(3)
+    let clock = ContinuousClock()
+    let task = Task {
+      try await sdk.awaitDeviceCodeAuthorization(code: "PENDING", pollInterval: interval)
+    }
+    await barrier.waitUntilParked()
+    let sleepStarted = clock.now
+    await barrier.release()
+    // Give the SDK time to resume from the observer and suspend inside `Task.sleep`.
+    try await Task.sleep(for: .milliseconds(250))
+    task.cancel()
+
+    do {
+      _ = try await task.value
+      XCTFail("Expected cancellation to propagate")
+    } catch is CancellationError {
+    }
+    XCTAssertEqual(counter.value, 1)
+    XCTAssertLessThan(
+      clock.now - sleepStarted, interval, "production sleep must not run to completion")
+  }
+
   // Cancellation after a poll has produced a result. The SDK parks at `.pollCompleted`
   // with `.authorized` already in hand; cancelling there and releasing proves the
   // post-poll cancellation check wins. Removing that check returns `.authorized` here.

--- a/Tests/PutioSDKTests/PutioSDKAuthTests.swift
+++ b/Tests/PutioSDKTests/PutioSDKAuthTests.swift
@@ -397,8 +397,11 @@ final class PutioSDKAuthTests: XCTestCase {
   }
 
   // The same loop on a clock that forwards to the real `ContinuousClock` after
-  // reporting entry. The SDK has no code between reaching the clock and the real sleep,
-  // so cancelling after entry can only be answered by the production sleep itself.
+  // reporting entry. This is cancellation-response coverage for the production clock,
+  // not a deterministic proof that cancellation lands mid-sleep: the test may cancel in
+  // the gap between the entry signal and `base.sleep` suspending. The deterministic
+  // mid-sleep proof is the observable-clock test above, where entry is reported from
+  // inside the suspension.
   func testAwaitDeviceCodeAuthorizationContinuousClockSleepIsInterruptedByCancellation()
     async throws
   {
@@ -758,8 +761,9 @@ private struct ObservableClock: Clock {
   }
 }
 
-// Forwards to a real clock after reporting entry synchronously, with no suspension
-// point in between.
+// Forwards to a real clock after reporting entry synchronously. A test observing the
+// signal can still race the subsequent `base.sleep`, so this spies on reach, not on an
+// active suspension.
 private struct SpyClock<Base: Clock>: Clock where Base.Duration == Swift.Duration {
   typealias Instant = Base.Instant
   typealias Duration = Swift.Duration

--- a/Tests/PutioSDKTests/PutioSDKAuthTests.swift
+++ b/Tests/PutioSDKTests/PutioSDKAuthTests.swift
@@ -355,9 +355,10 @@ final class PutioSDKAuthTests: XCTestCase {
     XCTAssertEqual(delegate.errors.map(\.statusCode), [500])
   }
 
-  // Cancellation during the sleep between polls. The SDK parks at its `.willSleep`
-  // boundary, the test cancels there, and the elapsed bound proves `Task.sleep` gave up
-  // immediately instead of waiting out the 60s interval.
+  // Cancellation during the sleep between polls. The interval sleep runs on a test
+  // clock that signals once the SDK is actually suspended inside `sleep`; the test
+  // cancels at that point. A sleeper that cannot be interrupted would keep the task
+  // alive until the 60s interval elapsed and trip the elapsed bound.
   func testAwaitDeviceCodeAuthorizationStopsWhenCancelledDuringSleep() async throws {
     let counter = PollCounter()
     try installMockRequestHandler { request in
@@ -369,9 +370,10 @@ final class PutioSDKAuthTests: XCTestCase {
       config: PutioSDKConfig(clientID: "ios-app", clientName: "put.io TV"),
       urlSession: makeTestSession()
     )
-    let barrier = PollBarrier()
-    sdk.deviceCodePollObserver = { event in
-      if event == .willSleep { await barrier.park() }
+    let sleeper = ObservableSleeper()
+    sdk.deviceCodePollSleeper = { interval in
+      XCTAssertEqual(interval, .seconds(60))
+      try await sleeper.sleep()
     }
 
     let clock = ContinuousClock()
@@ -379,9 +381,8 @@ final class PutioSDKAuthTests: XCTestCase {
     let task = Task {
       try await sdk.awaitDeviceCodeAuthorization(code: "PENDING", pollInterval: .seconds(60))
     }
-    await barrier.waitUntilParked()
+    await sleeper.waitUntilSleeping()
     task.cancel()
-    await barrier.release()
 
     do {
       _ = try await task.value
@@ -520,6 +521,51 @@ private final class RecordingDelegate: PutioSDKDelegate, @unchecked Sendable {
 // Suspending rendezvous between a test and the SDK's poll observer. `park` suspends the
 // SDK until `release`; `waitUntilParked` suspends the test until the SDK has parked.
 // Everything suspends rather than blocking, so no cooperative-pool thread is held.
+// Stand-in for `Task.sleep` that reports when the SDK is actually suspended inside it
+// and honours cancellation the same way `Task.sleep` does: the continuation resumes
+// with `CancellationError` when the sleeping task is cancelled, never on its own.
+private actor ObservableSleeper {
+  private var sleeper: CheckedContinuation<Void, Error>?
+  private var waiter: CheckedContinuation<Void, Never>?
+  private var isSleeping = false
+
+  func sleep() async throws {
+    try await withTaskCancellationHandler {
+      try await withCheckedThrowingContinuation {
+        (continuation: CheckedContinuation<Void, Error>) in
+        sleeper = continuation
+        isSleeping = true
+        waiter?.resume()
+        waiter = nil
+        // Like a real interval, the sleep eventually ends on its own. Long enough to
+        // trip the test's elapsed bound, short enough that a regression fails instead
+        // of hanging the suite.
+        Task {
+          try? await Task.sleep(for: .seconds(6))
+          await self.finish()
+        }
+      }
+    } onCancel: {
+      Task { await self.cancel() }
+    }
+  }
+
+  private func finish() {
+    sleeper?.resume()
+    sleeper = nil
+  }
+
+  func waitUntilSleeping() async {
+    if isSleeping { return }
+    await withCheckedContinuation { waiter = $0 }
+  }
+
+  private func cancel() {
+    sleeper?.resume(throwing: CancellationError())
+    sleeper = nil
+  }
+}
+
 private actor PollBarrier {
   private var parked: CheckedContinuation<Void, Never>?
   private var waiter: CheckedContinuation<Void, Never>?

--- a/Tests/PutioSDKTests/PutioSDKAuthTests.swift
+++ b/Tests/PutioSDKTests/PutioSDKAuthTests.swift
@@ -355,24 +355,33 @@ final class PutioSDKAuthTests: XCTestCase {
     XCTAssertEqual(delegate.errors.map(\.statusCode), [500])
   }
 
-  // Cancellation during the sleep between polls: the poll completes first (observed via
-  // URLSession task completion), the host gets time to enter its 60s sleep, and the
-  // elapsed bound proves the sleep itself was interrupted rather than waited out.
+  // Cancellation during the sleep between polls. The SDK parks at its `.willSleep`
+  // boundary, the test cancels there, and the elapsed bound proves `Task.sleep` gave up
+  // immediately instead of waiting out the 60s interval.
   func testAwaitDeviceCodeAuthorizationStopsWhenCancelledDuringSleep() async throws {
     let counter = PollCounter()
     try installMockRequestHandler { request in
       _ = counter.increment()
       return (makeHTTPResponse(for: request, statusCode: 200), Data(#"{"oauth_token":null}"#.utf8))
     }
-    let observer = TaskCompletionObserver()
-    let host = DeviceCodePollingHost(urlSession: makeTestSession(taskObserver: observer))
+
+    let sdk = PutioSDK(
+      config: PutioSDKConfig(clientID: "ios-app", clientName: "put.io TV"),
+      urlSession: makeTestSession()
+    )
+    let barrier = PollBarrier()
+    sdk.deviceCodePollObserver = { event in
+      if event == .willSleep { await barrier.park() }
+    }
 
     let clock = ContinuousClock()
     let start = clock.now
-    let task = Task { try await host.poll(code: "PENDING", pollInterval: .seconds(60)) }
-    try observer.waitUntilTaskCompleted()
-    try await Task.sleep(for: .milliseconds(200))
+    let task = Task {
+      try await sdk.awaitDeviceCodeAuthorization(code: "PENDING", pollInterval: .seconds(60))
+    }
+    await barrier.waitUntilParked()
     task.cancel()
+    await barrier.release()
 
     do {
       _ = try await task.value
@@ -383,36 +392,33 @@ final class PutioSDKAuthTests: XCTestCase {
     XCTAssertLessThan(clock.now - start, .seconds(5), "cancellation must interrupt the sleep")
   }
 
-  // Cancellation after a poll has produced a result: the host actor is held busy while
-  // the request completes, so the resumption carrying `.authorized` stays queued behind
-  // the hold. Cancelling before releasing the hold guarantees the post-poll check runs
-  // on a cancelled task with a result already in hand. Removing that check would return
-  // `.authorized` here.
+  // Cancellation after a poll has produced a result. The SDK parks at `.pollCompleted`
+  // with `.authorized` already in hand; cancelling there and releasing proves the
+  // post-poll cancellation check wins. Removing that check returns `.authorized` here.
   func testAwaitDeviceCodeAuthorizationDiscardsResultWhenCancelledAfterPollCompletes()
     async throws
   {
-    let gate = PollGate()
     try installMockRequestHandler { request in
-      gate.markRequestStarted()
-      try gate.waitUntilReleased()
-      return (
+      (
         makeHTTPResponse(for: request, statusCode: 200), Data(#"{"oauth_token":"tv-token"}"#.utf8)
       )
     }
-    let observer = TaskCompletionObserver()
-    let host = DeviceCodePollingHost(urlSession: makeTestSession(taskObserver: observer))
 
-    let task = Task { try await host.poll(code: "READY", pollInterval: .seconds(60)) }
-    try gate.waitUntilRequestStarted()
+    let sdk = PutioSDK(
+      config: PutioSDKConfig(clientID: "ios-app", clientName: "put.io TV"),
+      urlSession: makeTestSession()
+    )
+    let barrier = PollBarrier()
+    sdk.deviceCodePollObserver = { event in
+      if event == .pollCompleted { await barrier.park() }
+    }
 
-    let hold = ActorHold()
-    Task { await host.hold(hold) }
-    try hold.waitUntilHeld()
-
-    gate.release()
-    try observer.waitUntilTaskCompleted()
+    let task = Task {
+      try await sdk.awaitDeviceCodeAuthorization(code: "READY", pollInterval: .seconds(60))
+    }
+    await barrier.waitUntilParked()
     task.cancel()
-    hold.release()
+    await barrier.release()
 
     do {
       let authorization = try await task.value
@@ -511,64 +517,31 @@ private final class RecordingDelegate: PutioSDKDelegate, @unchecked Sendable {
   }
 }
 
-// Owns the SDK on an actor so `awaitDeviceCodeAuthorization` (caller-isolated under
-// NonisolatedNonsendingByDefault) resumes here after each poll; `hold` keeps the actor
-// busy so that resumption stays queued until the test releases it.
-private actor DeviceCodePollingHost {
-  private let sdk: PutioSDK
+// Suspending rendezvous between a test and the SDK's poll observer. `park` suspends the
+// SDK until `release`; `waitUntilParked` suspends the test until the SDK has parked.
+// Everything suspends rather than blocking, so no cooperative-pool thread is held.
+private actor PollBarrier {
+  private var parked: CheckedContinuation<Void, Never>?
+  private var waiter: CheckedContinuation<Void, Never>?
+  private var isParked = false
+  private var isReleased = false
 
-  init(urlSession: URLSession) {
-    sdk = PutioSDK(
-      config: PutioSDKConfig(clientID: "ios-app", clientName: "put.io TV"),
-      urlSession: urlSession)
+  func park() async {
+    isParked = true
+    waiter?.resume()
+    waiter = nil
+    if isReleased { return }
+    await withCheckedContinuation { parked = $0 }
   }
 
-  func poll(code: String, pollInterval: Duration) async throws -> PutioDeviceCodeAuthorization {
-    try await sdk.awaitDeviceCodeAuthorization(code: code, pollInterval: pollInterval)
+  func waitUntilParked() async {
+    if isParked { return }
+    await withCheckedContinuation { waiter = $0 }
   }
 
-  func hold(_ hold: ActorHold) {
-    hold.markHeld()
-    hold.waitUntilReleased()
+  func release() {
+    isReleased = true
+    parked?.resume()
+    parked = nil
   }
-}
-
-private final class ActorHold: @unchecked Sendable {
-  private let held = DispatchSemaphore(value: 0)
-  private let released = DispatchSemaphore(value: 0)
-
-  func markHeld() { held.signal() }
-
-  func waitUntilHeld() throws {
-    guard held.wait(timeout: .now() + .seconds(5)) == .success else {
-      throw TestSynchronizationTimeout(stage: "actor hold")
-    }
-  }
-
-  func waitUntilReleased() {
-    _ = released.wait(timeout: .now() + .seconds(5))
-  }
-
-  func release() { released.signal() }
-}
-
-private final class PollGate: @unchecked Sendable {
-  private let started = DispatchSemaphore(value: 0)
-  private let released = DispatchSemaphore(value: 0)
-
-  func markRequestStarted() { started.signal() }
-
-  func waitUntilRequestStarted() throws {
-    guard started.wait(timeout: .now() + .seconds(5)) == .success else {
-      throw TestSynchronizationTimeout(stage: "poll request start")
-    }
-  }
-
-  func waitUntilReleased() throws {
-    guard released.wait(timeout: .now() + .seconds(5)) == .success else {
-      throw TestSynchronizationTimeout(stage: "poll release")
-    }
-  }
-
-  func release() { released.signal() }
 }

--- a/Tests/PutioSDKTests/PutioSDKAuthTests.swift
+++ b/Tests/PutioSDKTests/PutioSDKAuthTests.swift
@@ -381,7 +381,8 @@ final class PutioSDKAuthTests: XCTestCase {
     let task = Task {
       try await sdk.awaitDeviceCodeAuthorization(code: "PENDING", pollInterval: .seconds(60))
     }
-    await sleeper.waitUntilSleeping()
+    defer { Task { await sleeper.abandon() } }
+    try await sleeper.waitUntilSleeping()
     task.cancel()
 
     do {
@@ -420,7 +421,8 @@ final class PutioSDKAuthTests: XCTestCase {
     let task = Task {
       try await sdk.awaitDeviceCodeAuthorization(code: "PENDING", pollInterval: interval)
     }
-    await barrier.waitUntilParked()
+    defer { Task { await barrier.abandon() } }
+    try await barrier.waitUntilParked()
     let sleepStarted = clock.now
     await barrier.release()
     // Give the SDK time to resume from the observer and suspend inside `Task.sleep`.
@@ -461,7 +463,8 @@ final class PutioSDKAuthTests: XCTestCase {
     let task = Task {
       try await sdk.awaitDeviceCodeAuthorization(code: "READY", pollInterval: .seconds(60))
     }
-    await barrier.waitUntilParked()
+    defer { Task { await barrier.abandon() } }
+    try await barrier.waitUntilParked()
     task.cancel()
     await barrier.release()
 
@@ -570,7 +573,7 @@ private final class RecordingDelegate: PutioSDKDelegate, @unchecked Sendable {
 // with `CancellationError` when the sleeping task is cancelled, never on its own.
 private actor ObservableSleeper {
   private var sleeper: CheckedContinuation<Void, Error>?
-  private var waiter: CheckedContinuation<Void, Never>?
+  private var waiter: CheckedContinuation<Void, Error>?
   private var isSleeping = false
 
   func sleep() async throws {
@@ -599,9 +602,33 @@ private actor ObservableSleeper {
     sleeper = nil
   }
 
-  func waitUntilSleeping() async {
+  func waitUntilSleeping() async throws {
     if isSleeping { return }
-    await withCheckedContinuation { waiter = $0 }
+    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+      waiter = continuation
+      scheduleDeadline(stage: "SDK to enter the poll sleep")
+    }
+  }
+
+  // Failure cleanup: wake anything still suspended so a failed test reports instead of
+  // hanging on a continuation nobody will resume.
+  func abandon() {
+    waiter?.resume(throwing: RendezvousTimeout(stage: "abandoned sleeper wait"))
+    waiter = nil
+    sleeper?.resume(throwing: CancellationError())
+    sleeper = nil
+  }
+
+  private func scheduleDeadline(stage: String) {
+    Task {
+      try? await Task.sleep(for: .seconds(5))
+      await self.expireWaiter(stage: stage)
+    }
+  }
+
+  private func expireWaiter(stage: String) {
+    waiter?.resume(throwing: RendezvousTimeout(stage: stage))
+    waiter = nil
   }
 
   private func cancel() {
@@ -612,7 +639,7 @@ private actor ObservableSleeper {
 
 private actor PollBarrier {
   private var parked: CheckedContinuation<Void, Never>?
-  private var waiter: CheckedContinuation<Void, Never>?
+  private var waiter: CheckedContinuation<Void, Error>?
   private var isParked = false
   private var isReleased = false
 
@@ -624,9 +651,12 @@ private actor PollBarrier {
     await withCheckedContinuation { parked = $0 }
   }
 
-  func waitUntilParked() async {
+  func waitUntilParked() async throws {
     if isParked { return }
-    await withCheckedContinuation { waiter = $0 }
+    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+      waiter = continuation
+      scheduleDeadline(stage: "SDK to park at the observer")
+    }
   }
 
   func release() {
@@ -634,4 +664,31 @@ private actor PollBarrier {
     parked?.resume()
     parked = nil
   }
+
+  // Failure cleanup: wake anything still suspended so a failed test reports instead of
+  // hanging on a continuation nobody will resume.
+  func abandon() {
+    waiter?.resume(throwing: RendezvousTimeout(stage: "abandoned barrier wait"))
+    waiter = nil
+    release()
+  }
+
+  private func scheduleDeadline(stage: String) {
+    Task {
+      try? await Task.sleep(for: .seconds(5))
+      await self.expireWaiter(stage: stage)
+    }
+  }
+
+  private func expireWaiter(stage: String) {
+    waiter?.resume(throwing: RendezvousTimeout(stage: stage))
+    waiter = nil
+  }
+}
+
+// A rendezvous that never happens fails the test loudly after five seconds instead of
+// hanging on a continuation nobody will resume.
+private struct RendezvousTimeout: Error, CustomStringConvertible {
+  let stage: String
+  var description: String { "timed out waiting for \(stage)" }
 }

--- a/Tests/PutioSDKTests/PutioSDKAuthTests.swift
+++ b/Tests/PutioSDKTests/PutioSDKAuthTests.swift
@@ -394,10 +394,12 @@ final class PutioSDKAuthTests: XCTestCase {
     XCTAssertLessThan(clock.now - start, .seconds(5), "cancellation must interrupt the sleep")
   }
 
-  // Same contract against the production sleeper. The observer parks at `.willSleep`,
-  // is released, and the SDK enters the real `Task.sleep` for a short interval before
-  // the test cancels. An uncancellable production sleeper would wait out the whole
-  // interval and trip the elapsed bound; a cancellable one returns almost immediately.
+  // Same contract against the production sleep primitive. The wrapper signals entry
+  // synchronously and then calls `PutioSDK.sleepBetweenDeviceCodePolls` with no
+  // suspension point in between, so once the test observes entry the SDK task is either
+  // about to enter or already inside the real `Task.sleep`; cancelling there must
+  // interrupt it. A default sleeper that cannot be cancelled waits out the interval and
+  // trips the elapsed bound.
   func testAwaitDeviceCodeAuthorizationProductionSleepIsInterruptedByCancellation()
     async throws
   {
@@ -411,22 +413,20 @@ final class PutioSDKAuthTests: XCTestCase {
       config: PutioSDKConfig(clientID: "ios-app", clientName: "put.io TV"),
       urlSession: makeTestSession()
     )
-    let barrier = PollBarrier()
-    sdk.deviceCodePollObserver = { event in
-      if event == .willSleep { await barrier.park() }
+    let entry = SleepEntrySignal()
+    sdk.deviceCodePollSleeper = { interval in
+      entry.markEntered()
+      try await PutioSDK.sleepBetweenDeviceCodePolls(interval)
     }
 
-    let interval = Duration.seconds(3)
+    let interval = Duration.seconds(5)
     let clock = ContinuousClock()
     let task = Task {
       try await sdk.awaitDeviceCodeAuthorization(code: "PENDING", pollInterval: interval)
     }
-    defer { Task { await barrier.abandon() } }
-    try await barrier.waitUntilParked()
-    let sleepStarted = clock.now
-    await barrier.release()
-    // Give the SDK time to resume from the observer and suspend inside `Task.sleep`.
-    try await Task.sleep(for: .milliseconds(250))
+    defer { entry.abandon() }
+    try await entry.waitUntilEntered()
+    let entered = clock.now
     task.cancel()
 
     do {
@@ -435,8 +435,7 @@ final class PutioSDKAuthTests: XCTestCase {
     } catch is CancellationError {
     }
     XCTAssertEqual(counter.value, 1)
-    XCTAssertLessThan(
-      clock.now - sleepStarted, interval, "production sleep must not run to completion")
+    XCTAssertLessThan(clock.now - entered, interval, "production sleep must not run to completion")
   }
 
   // Cancellation after a poll has produced a result. The SDK parks at `.pollCompleted`
@@ -634,6 +633,52 @@ private actor ObservableSleeper {
   private func cancel() {
     sleeper?.resume(throwing: CancellationError())
     sleeper = nil
+  }
+}
+
+// Synchronous entry signal for the production-sleep test. `markEntered` never suspends,
+// so the SDK task proceeds straight from it into the real sleep primitive.
+private final class SleepEntrySignal: @unchecked Sendable {
+  private let lock = NSLock()
+  private var entered = false
+  private var waiter: CheckedContinuation<Void, Error>?
+
+  func markEntered() {
+    lock.lock()
+    entered = true
+    let waiter = self.waiter
+    self.waiter = nil
+    lock.unlock()
+    waiter?.resume()
+  }
+
+  func waitUntilEntered() async throws {
+    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+      lock.lock()
+      if entered {
+        lock.unlock()
+        continuation.resume()
+        return
+      }
+      waiter = continuation
+      lock.unlock()
+      Task {
+        try? await Task.sleep(for: .seconds(5))
+        self.expire()
+      }
+    }
+  }
+
+  func abandon() {
+    expire()
+  }
+
+  private func expire() {
+    lock.lock()
+    let waiter = self.waiter
+    self.waiter = nil
+    lock.unlock()
+    waiter?.resume(throwing: RendezvousTimeout(stage: "SDK to enter the production sleep"))
   }
 }
 

--- a/Tests/PutioSDKTests/PutioSDKAuthTests.swift
+++ b/Tests/PutioSDKTests/PutioSDKAuthTests.swift
@@ -397,9 +397,9 @@ final class PutioSDKAuthTests: XCTestCase {
   // Same contract against the production sleep primitive. The wrapper signals entry
   // synchronously and then calls `PutioSDK.sleepBetweenDeviceCodePolls` with no
   // suspension point in between, so once the test observes entry the SDK task is either
-  // about to enter or already inside the real `Task.sleep`; cancelling there must
-  // interrupt it. A default sleeper that cannot be cancelled waits out the interval and
-  // trips the elapsed bound.
+  // about to enter or already inside the real `Task.sleep`. The bound is on the response
+  // to cancellation, far below the interval, so an uncancellable primitive that waits out
+  // its interval fails regardless of when the test happened to observe entry.
   func testAwaitDeviceCodeAuthorizationProductionSleepIsInterruptedByCancellation()
     async throws
   {
@@ -419,23 +419,85 @@ final class PutioSDKAuthTests: XCTestCase {
       try await PutioSDK.sleepBetweenDeviceCodePolls(interval)
     }
 
-    let interval = Duration.seconds(5)
-    let clock = ContinuousClock()
     let task = Task {
-      try await sdk.awaitDeviceCodeAuthorization(code: "PENDING", pollInterval: interval)
+      try await sdk.awaitDeviceCodeAuthorization(code: "PENDING", pollInterval: .seconds(20))
     }
     defer { entry.abandon() }
     try await entry.waitUntilEntered()
-    let entered = clock.now
-    task.cancel()
 
+    let clock = ContinuousClock()
+    let cancelled = clock.now
+    task.cancel()
     do {
       _ = try await task.value
       XCTFail("Expected cancellation to propagate")
     } catch is CancellationError {
     }
     XCTAssertEqual(counter.value, 1)
-    XCTAssertLessThan(clock.now - entered, interval, "production sleep must not run to completion")
+    XCTAssertLessThan(
+      clock.now - cancelled, .seconds(2), "production sleep must respond to cancellation")
+  }
+
+  // The shipped default sleeper, exercised directly: it must be the cancellable
+  // primitive, not a detached or pre-checked stand-in.
+  func testDefaultDeviceCodePollSleeperIsInterruptedByCancellation() async throws {
+    let sdk = PutioSDK(config: PutioSDKConfig(clientID: "ios-app", clientName: "put.io TV"))
+    let sleeper = sdk.deviceCodePollSleeper
+
+    let task = Task { try await sleeper(.seconds(20)) }
+    try await Task.sleep(for: .milliseconds(300))
+
+    let clock = ContinuousClock()
+    let cancelled = clock.now
+    task.cancel()
+    do {
+      try await task.value
+      XCTFail("Expected cancellation to propagate")
+    } catch is CancellationError {
+    }
+    XCTAssertLessThan(
+      clock.now - cancelled, .seconds(2), "default sleeper must respond to cancellation")
+  }
+
+  // The full polling loop with the default sleeper installed. The observer only parks
+  // at `.willSleep` and releases; the interval sleep that follows is the shipped one.
+  func testAwaitDeviceCodeAuthorizationWithDefaultSleeperIsInterruptedByCancellation()
+    async throws
+  {
+    let counter = PollCounter()
+    try installMockRequestHandler { request in
+      _ = counter.increment()
+      return (makeHTTPResponse(for: request, statusCode: 200), Data(#"{"oauth_token":null}"#.utf8))
+    }
+
+    let sdk = PutioSDK(
+      config: PutioSDKConfig(clientID: "ios-app", clientName: "put.io TV"),
+      urlSession: makeTestSession()
+    )
+    let barrier = PollBarrier()
+    sdk.deviceCodePollObserver = { event in
+      if event == .willSleep { await barrier.park() }
+    }
+
+    let task = Task {
+      try await sdk.awaitDeviceCodeAuthorization(code: "PENDING", pollInterval: .seconds(20))
+    }
+    defer { Task { await barrier.abandon() } }
+    try await barrier.waitUntilParked()
+    await barrier.release()
+    try await Task.sleep(for: .milliseconds(300))
+
+    let clock = ContinuousClock()
+    let cancelled = clock.now
+    task.cancel()
+    do {
+      _ = try await task.value
+      XCTFail("Expected cancellation to propagate")
+    } catch is CancellationError {
+    }
+    XCTAssertEqual(counter.value, 1)
+    XCTAssertLessThan(
+      clock.now - cancelled, .seconds(2), "default polling sleep must respond to cancellation")
   }
 
   // Cancellation after a poll has produced a result. The SDK parks at `.pollCompleted`

--- a/Tests/PutioSDKTests/PutioSDKAuthTests.swift
+++ b/Tests/PutioSDKTests/PutioSDKAuthTests.swift
@@ -381,7 +381,10 @@ final class PutioSDKAuthTests: XCTestCase {
     let task = Task {
       try await sdk.awaitDeviceCodeAuthorization(code: "PENDING", pollInterval: .seconds(60))
     }
-    defer { Task { await sleeper.abandon() } }
+    defer {
+      task.cancel()
+      Task { await sleeper.abandon() }
+    }
     try await sleeper.waitUntilSleeping()
     task.cancel()
 
@@ -394,58 +397,21 @@ final class PutioSDKAuthTests: XCTestCase {
     XCTAssertLessThan(clock.now - start, .seconds(5), "cancellation must interrupt the sleep")
   }
 
-  // Same contract against the production sleep primitive. The wrapper signals entry
-  // synchronously and then calls `PutioSDK.sleepBetweenDeviceCodePolls` with no
-  // suspension point in between, so once the test observes entry the SDK task is either
-  // about to enter or already inside the real `Task.sleep`. The bound is on the response
-  // to cancellation, far below the interval, so an uncancellable primitive that waits out
-  // its interval fails regardless of when the test happened to observe entry.
-  func testAwaitDeviceCodeAuthorizationProductionSleepIsInterruptedByCancellation()
-    async throws
-  {
-    let counter = PollCounter()
-    try installMockRequestHandler { request in
-      _ = counter.increment()
-      return (makeHTTPResponse(for: request, statusCode: 200), Data(#"{"oauth_token":null}"#.utf8))
-    }
-
-    let sdk = PutioSDK(
-      config: PutioSDKConfig(clientID: "ios-app", clientName: "put.io TV"),
-      urlSession: makeTestSession()
-    )
+  // The shipped sleep primitive, exercised directly. Its entry hook fires synchronously
+  // immediately before `Task.sleep`, so once the test observes entry there is no
+  // suspension point left before the real sleep; cancelling there must interrupt it. The
+  // bound is on the response to cancellation, far below the interval, so an
+  // uncancellable primitive that waits out its interval fails deterministically.
+  func testProductionDeviceCodeSleepIsInterruptedByCancellation() async throws {
     let entry = SleepEntrySignal()
-    sdk.deviceCodePollSleeper = { interval in
-      entry.markEntered()
-      try await PutioSDK.sleepBetweenDeviceCodePolls(interval)
-    }
-
     let task = Task {
-      try await sdk.awaitDeviceCodeAuthorization(code: "PENDING", pollInterval: .seconds(20))
+      try await PutioSDK.sleepBetweenDeviceCodePolls(.seconds(20), onEntry: entry.markEntered)
     }
-    defer { entry.abandon() }
+    defer {
+      task.cancel()
+      entry.abandon()
+    }
     try await entry.waitUntilEntered()
-
-    let clock = ContinuousClock()
-    let cancelled = clock.now
-    task.cancel()
-    do {
-      _ = try await task.value
-      XCTFail("Expected cancellation to propagate")
-    } catch is CancellationError {
-    }
-    XCTAssertEqual(counter.value, 1)
-    XCTAssertLessThan(
-      clock.now - cancelled, .seconds(2), "production sleep must respond to cancellation")
-  }
-
-  // The shipped default sleeper, exercised directly: it must be the cancellable
-  // primitive, not a detached or pre-checked stand-in.
-  func testDefaultDeviceCodePollSleeperIsInterruptedByCancellation() async throws {
-    let sdk = PutioSDK(config: PutioSDKConfig(clientID: "ios-app", clientName: "put.io TV"))
-    let sleeper = sdk.deviceCodePollSleeper
-
-    let task = Task { try await sleeper(.seconds(20)) }
-    try await Task.sleep(for: .milliseconds(300))
 
     let clock = ContinuousClock()
     let cancelled = clock.now
@@ -456,11 +422,12 @@ final class PutioSDKAuthTests: XCTestCase {
     } catch is CancellationError {
     }
     XCTAssertLessThan(
-      clock.now - cancelled, .seconds(2), "default sleeper must respond to cancellation")
+      clock.now - cancelled, .seconds(2), "production sleep must respond to cancellation")
   }
 
-  // The full polling loop with the default sleeper installed. The observer only parks
-  // at `.willSleep` and releases; the interval sleep that follows is the shipped one.
+  // The full polling loop with no sleeper override, so the interval sleep is the shipped
+  // primitive. The entry observer proves the loop reached that primitive before the
+  // test cancels.
   func testAwaitDeviceCodeAuthorizationWithDefaultSleeperIsInterruptedByCancellation()
     async throws
   {
@@ -474,18 +441,17 @@ final class PutioSDKAuthTests: XCTestCase {
       config: PutioSDKConfig(clientID: "ios-app", clientName: "put.io TV"),
       urlSession: makeTestSession()
     )
-    let barrier = PollBarrier()
-    sdk.deviceCodePollObserver = { event in
-      if event == .willSleep { await barrier.park() }
-    }
+    let entry = SleepEntrySignal()
+    sdk.deviceCodeSleepEntryObserver = entry.markEntered
 
     let task = Task {
       try await sdk.awaitDeviceCodeAuthorization(code: "PENDING", pollInterval: .seconds(20))
     }
-    defer { Task { await barrier.abandon() } }
-    try await barrier.waitUntilParked()
-    await barrier.release()
-    try await Task.sleep(for: .milliseconds(300))
+    defer {
+      task.cancel()
+      entry.abandon()
+    }
+    try await entry.waitUntilEntered()
 
     let clock = ContinuousClock()
     let cancelled = clock.now
@@ -524,7 +490,10 @@ final class PutioSDKAuthTests: XCTestCase {
     let task = Task {
       try await sdk.awaitDeviceCodeAuthorization(code: "READY", pollInterval: .seconds(60))
     }
-    defer { Task { await barrier.abandon() } }
+    defer {
+      task.cancel()
+      Task { await barrier.abandon() }
+    }
     try await barrier.waitUntilParked()
     task.cancel()
     await barrier.release()

--- a/Tests/PutioSDKTests/PutioSDKAuthTests.swift
+++ b/Tests/PutioSDKTests/PutioSDKAuthTests.swift
@@ -355,10 +355,10 @@ final class PutioSDKAuthTests: XCTestCase {
     XCTAssertEqual(delegate.errors.map(\.statusCode), [500])
   }
 
-  // Cancellation during the sleep between polls. The interval sleep runs on a test
-  // clock that signals once the SDK is actually suspended inside `sleep`; the test
-  // cancels at that point. A sleeper that cannot be interrupted would keep the task
-  // alive until the 60s interval elapsed and trip the elapsed bound.
+  // Cancellation during the sleep between polls. The interval sleep runs on a test clock
+  // whose `sleep` reports entry from inside the suspension, so once the test observes
+  // entry the SDK task is inside the sleep with no SDK code left to run before it. The
+  // clock resumes only on cancellation (or a 6s fallback that trips the response bound).
   func testAwaitDeviceCodeAuthorizationStopsWhenCancelledDuringSleep() async throws {
     let counter = PollCounter()
     try installMockRequestHandler { request in
@@ -371,13 +371,8 @@ final class PutioSDKAuthTests: XCTestCase {
       urlSession: makeTestSession()
     )
     let sleeper = ObservableSleeper()
-    sdk.deviceCodePollSleeper = { interval in
-      XCTAssertEqual(interval, .seconds(60))
-      try await sleeper.sleep()
-    }
+    sdk.deviceCodePollClock = ObservableClock(sleeper: sleeper)
 
-    let clock = ContinuousClock()
-    let start = clock.now
     let task = Task {
       try await sdk.awaitDeviceCodeAuthorization(code: "PENDING", pollInterval: .seconds(60))
     }
@@ -386,49 +381,25 @@ final class PutioSDKAuthTests: XCTestCase {
       Task { await sleeper.abandon() }
     }
     try await sleeper.waitUntilSleeping()
-    task.cancel()
+    let requested = await sleeper.requestedInterval
+    XCTAssertEqual(requested, .seconds(60))
 
+    let clock = ContinuousClock()
+    let cancelled = clock.now
+    task.cancel()
     do {
       _ = try await task.value
       XCTFail("Expected cancellation to propagate")
     } catch is CancellationError {
     }
     XCTAssertEqual(counter.value, 1)
-    XCTAssertLessThan(clock.now - start, .seconds(5), "cancellation must interrupt the sleep")
+    XCTAssertLessThan(clock.now - cancelled, .seconds(2), "cancellation must interrupt the sleep")
   }
 
-  // The shipped sleep primitive, exercised directly. Its entry hook fires synchronously
-  // immediately before `Task.sleep`, so once the test observes entry there is no
-  // suspension point left before the real sleep; cancelling there must interrupt it. The
-  // bound is on the response to cancellation, far below the interval, so an
-  // uncancellable primitive that waits out its interval fails deterministically.
-  func testProductionDeviceCodeSleepIsInterruptedByCancellation() async throws {
-    let entry = SleepEntrySignal()
-    let task = Task {
-      try await PutioSDK.sleepBetweenDeviceCodePolls(.seconds(20), onEntry: entry.markEntered)
-    }
-    defer {
-      task.cancel()
-      entry.abandon()
-    }
-    try await entry.waitUntilEntered()
-
-    let clock = ContinuousClock()
-    let cancelled = clock.now
-    task.cancel()
-    do {
-      try await task.value
-      XCTFail("Expected cancellation to propagate")
-    } catch is CancellationError {
-    }
-    XCTAssertLessThan(
-      clock.now - cancelled, .seconds(2), "production sleep must respond to cancellation")
-  }
-
-  // The full polling loop with no sleeper override, so the interval sleep is the shipped
-  // primitive. The entry observer proves the loop reached that primitive before the
-  // test cancels.
-  func testAwaitDeviceCodeAuthorizationWithDefaultSleeperIsInterruptedByCancellation()
+  // The same loop on a clock that forwards to the real `ContinuousClock` after
+  // reporting entry. The SDK has no code between reaching the clock and the real sleep,
+  // so cancelling after entry can only be answered by the production sleep itself.
+  func testAwaitDeviceCodeAuthorizationContinuousClockSleepIsInterruptedByCancellation()
     async throws
   {
     let counter = PollCounter()
@@ -442,7 +413,7 @@ final class PutioSDKAuthTests: XCTestCase {
       urlSession: makeTestSession()
     )
     let entry = SleepEntrySignal()
-    sdk.deviceCodeSleepEntryObserver = entry.markEntered
+    sdk.deviceCodePollClock = SpyClock(base: ContinuousClock(), onSleep: entry.markEntered)
 
     let task = Task {
       try await sdk.awaitDeviceCodeAuthorization(code: "PENDING", pollInterval: .seconds(20))
@@ -463,7 +434,52 @@ final class PutioSDKAuthTests: XCTestCase {
     }
     XCTAssertEqual(counter.value, 1)
     XCTAssertLessThan(
-      clock.now - cancelled, .seconds(2), "default polling sleep must respond to cancellation")
+      clock.now - cancelled, .seconds(2), "continuous clock sleep must respond to cancellation")
+  }
+
+  // The shipped wiring: the default clock is the continuous clock, and the loop with no
+  // override responds to cancellation during its interval. Entry cannot be observed on
+  // the stdlib clock, so this test only bounds the response; the two tests above carry
+  // the deterministic proof.
+  func testAwaitDeviceCodeAuthorizationDefaultClockIsInterruptedByCancellation() async throws {
+    let counter = PollCounter()
+    try installMockRequestHandler { request in
+      _ = counter.increment()
+      return (makeHTTPResponse(for: request, statusCode: 200), Data(#"{"oauth_token":null}"#.utf8))
+    }
+
+    let sdk = PutioSDK(
+      config: PutioSDKConfig(clientID: "ios-app", clientName: "put.io TV"),
+      urlSession: makeTestSession()
+    )
+    XCTAssertTrue(sdk.deviceCodePollClock is ContinuousClock)
+    let barrier = PollBarrier()
+    sdk.deviceCodePollObserver = { event in
+      if event == .willSleep { await barrier.park() }
+    }
+
+    let task = Task {
+      try await sdk.awaitDeviceCodeAuthorization(code: "PENDING", pollInterval: .seconds(20))
+    }
+    defer {
+      task.cancel()
+      Task { await barrier.abandon() }
+    }
+    try await barrier.waitUntilParked()
+    await barrier.release()
+    try await Task.sleep(for: .milliseconds(300))
+
+    let clock = ContinuousClock()
+    let cancelled = clock.now
+    task.cancel()
+    do {
+      _ = try await task.value
+      XCTFail("Expected cancellation to propagate")
+    } catch is CancellationError {
+    }
+    XCTAssertEqual(counter.value, 1)
+    XCTAssertLessThan(
+      clock.now - cancelled, .seconds(2), "default clock sleep must respond to cancellation")
   }
 
   // Cancellation after a poll has produced a result. The SDK parks at `.pollCompleted`
@@ -605,6 +621,12 @@ private actor ObservableSleeper {
   private var sleeper: CheckedContinuation<Void, Error>?
   private var waiter: CheckedContinuation<Void, Error>?
   private var isSleeping = false
+  private(set) var requestedInterval: Duration?
+
+  func sleep(for interval: Duration) async throws {
+    requestedInterval = interval
+    try await sleep()
+  }
 
   func sleep() async throws {
     try await withTaskCancellationHandler {
@@ -710,6 +732,47 @@ private final class SleepEntrySignal: @unchecked Sendable {
     self.waiter = nil
     lock.unlock()
     waiter?.resume(throwing: RendezvousTimeout(stage: "SDK to enter the production sleep"))
+  }
+}
+
+// Test clock whose only behaviour is the observable sleep above. `now` is real time so
+// `sleep(for:)` deadlines are well formed; the duration is recovered from the deadline.
+private struct ObservableClock: Clock {
+  typealias Instant = ContinuousClock.Instant
+  typealias Duration = Swift.Duration
+
+  let sleeper: ObservableSleeper
+  private let base = ContinuousClock()
+
+  var now: Instant { base.now }
+  var minimumResolution: Duration { base.minimumResolution }
+
+  func sleep(until deadline: Instant, tolerance: Duration?) async throws {
+    let interval = deadline - base.now
+    try await sleeper.sleep(for: roundedToSeconds(interval))
+  }
+
+  private func roundedToSeconds(_ duration: Duration) -> Duration {
+    let seconds = (duration.components.seconds, duration.components.attoseconds)
+    return .seconds(seconds.0 + (seconds.1 >= 500_000_000_000_000_000 ? 1 : 0))
+  }
+}
+
+// Forwards to a real clock after reporting entry synchronously, with no suspension
+// point in between.
+private struct SpyClock<Base: Clock>: Clock where Base.Duration == Swift.Duration {
+  typealias Instant = Base.Instant
+  typealias Duration = Swift.Duration
+
+  let base: Base
+  let onSleep: @Sendable () -> Void
+
+  var now: Instant { base.now }
+  var minimumResolution: Duration { base.minimumResolution }
+
+  func sleep(until deadline: Instant, tolerance: Duration?) async throws {
+    onSleep()
+    try await base.sleep(until: deadline, tolerance: tolerance)
   }
 }
 

--- a/Tests/PutioSDKTests/PutioSDKTransportTests.swift
+++ b/Tests/PutioSDKTests/PutioSDKTransportTests.swift
@@ -70,7 +70,8 @@ final class PutioSDKTransportTests: XCTestCase {
   // delegate released while a request is in flight is neither kept alive nor called.
   // The config snapshot itself has no deterministic unit proof: the mock transport only
   // observes a request after the SDK has already read `config`, so an ordering test
-  // cannot distinguish the on-actor snapshot from the old off-actor read.
+  // cannot distinguish the on-actor snapshot from the old off-actor read. That shape is
+  // enforced structurally by scripts/check-transport-isolation.sh in `make verify`.
   func testInFlightRequestDoesNotRetainReleasedDelegate() async throws {
     let gate = RequestGate()
     try installMockRequestHandler { request in
@@ -100,6 +101,33 @@ final class PutioSDKTransportTests: XCTestCase {
       XCTAssertEqual(error.statusCode, 500)
     }
     XCTAssertNil(sdk.delegate)
+  }
+
+  // docs/ARCHITECTURE.md contract: delegate callbacks come from the global executor,
+  // never inline on the caller's actor. Calling from the main actor makes "not on the
+  // main thread" a faithful proxy for "off the caller's actor".
+  @MainActor
+  func testDelegateCallbacksArriveOffTheCallerActor() async throws {
+    try installMockRequestHandler { request in
+      (makeHTTPResponse(for: request, statusCode: 500), Data(#"{"status":"ERROR"}"#.utf8))
+    }
+
+    let sdk = PutioSDK(
+      config: PutioSDKConfig(clientID: "ios-app", token: "token-123"),
+      urlSession: makeTestSession()
+    )
+    let delegate = ThreadRecordingDelegate()
+    sdk.delegate = delegate
+
+    do {
+      _ = try await sdk.getAccountInfo()
+      XCTFail("Expected HTTP 500 to surface as an error")
+    } catch let error as PutioSDKError {
+      XCTAssertEqual(error.statusCode, 500)
+    }
+
+    XCTAssertEqual(delegate.callbacks.map(\.statusCode), [500])
+    XCTAssertEqual(delegate.callbacks.map(\.onMainThread), [false])
   }
 
   func testGetFileSurfacesTypedHttpErrors() async throws {
@@ -298,4 +326,26 @@ private struct RequestGateTimeout: Error, CustomStringConvertible {
 
 private final class RecordingDelegate: PutioSDKDelegate {
   func onPutioSDKError(error: PutioSDKError) {}
+}
+
+private final class ThreadRecordingDelegate: PutioSDKDelegate, @unchecked Sendable {
+  struct Callback {
+    let statusCode: Int?
+    let onMainThread: Bool
+  }
+
+  private let lock = NSLock()
+  private var recorded: [Callback] = []
+
+  var callbacks: [Callback] {
+    lock.lock()
+    defer { lock.unlock() }
+    return recorded
+  }
+
+  func onPutioSDKError(error: PutioSDKError) {
+    lock.lock()
+    recorded.append(Callback(statusCode: error.statusCode, onMainThread: Thread.isMainThread))
+    lock.unlock()
+  }
 }

--- a/Tests/PutioSDKTests/TransportSupport.swift
+++ b/Tests/PutioSDKTests/TransportSupport.swift
@@ -48,10 +48,35 @@ final class MockURLProtocol: URLProtocol {
   override func stopLoading() {}
 }
 
-func makeTestSession() -> URLSession {
+func makeTestSession(taskObserver: TaskCompletionObserver? = nil) -> URLSession {
   let configuration = URLSessionConfiguration.ephemeral
   configuration.protocolClasses = [MockURLProtocol.self]
-  return URLSession(configuration: configuration)
+  return URLSession(configuration: configuration, delegate: taskObserver, delegateQueue: nil)
+}
+
+// Signals once URLSession has finished a task, which is the earliest point at which
+// cancelling the calling task can no longer surface as `URLError.cancelled`. The async
+// `data(for:)` API consumes `didCompleteWithError` itself and only forwards the metrics
+// callback to the session delegate, so that is the completion signal observed here.
+final class TaskCompletionObserver: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
+  private let completed = DispatchSemaphore(value: 0)
+
+  func urlSession(
+    _ session: URLSession, task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics
+  ) {
+    completed.signal()
+  }
+
+  func waitUntilTaskCompleted(timeout: DispatchTimeInterval = .seconds(5)) throws {
+    guard completed.wait(timeout: .now() + timeout) == .success else {
+      throw TestSynchronizationTimeout(stage: "URLSession task completion")
+    }
+  }
+}
+
+struct TestSynchronizationTimeout: Error, CustomStringConvertible {
+  let stage: String
+  var description: String { "timed out waiting for \(stage)" }
 }
 
 func makeHTTPResponse(for request: URLRequest, statusCode: Int) -> HTTPURLResponse {

--- a/Tests/PutioSDKTests/TransportSupport.swift
+++ b/Tests/PutioSDKTests/TransportSupport.swift
@@ -48,35 +48,10 @@ final class MockURLProtocol: URLProtocol {
   override func stopLoading() {}
 }
 
-func makeTestSession(taskObserver: TaskCompletionObserver? = nil) -> URLSession {
+func makeTestSession() -> URLSession {
   let configuration = URLSessionConfiguration.ephemeral
   configuration.protocolClasses = [MockURLProtocol.self]
-  return URLSession(configuration: configuration, delegate: taskObserver, delegateQueue: nil)
-}
-
-// Signals once URLSession has finished a task, which is the earliest point at which
-// cancelling the calling task can no longer surface as `URLError.cancelled`. The async
-// `data(for:)` API consumes `didCompleteWithError` itself and only forwards the metrics
-// callback to the session delegate, so that is the completion signal observed here.
-final class TaskCompletionObserver: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
-  private let completed = DispatchSemaphore(value: 0)
-
-  func urlSession(
-    _ session: URLSession, task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics
-  ) {
-    completed.signal()
-  }
-
-  func waitUntilTaskCompleted(timeout: DispatchTimeInterval = .seconds(5)) throws {
-    guard completed.wait(timeout: .now() + timeout) == .success else {
-      throw TestSynchronizationTimeout(stage: "URLSession task completion")
-    }
-  }
-}
-
-struct TestSynchronizationTimeout: Error, CustomStringConvertible {
-  let stage: String
-  var description: String { "timed out waiting for \(stage)" }
+  return URLSession(configuration: configuration)
 }
 
 func makeHTTPResponse(for request: URLRequest, statusCode: Int) -> HTTPURLResponse {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -87,7 +87,8 @@ thread. `@concurrent` keeps that CPU work on the global executor, while the
 public domain methods that call into `request` keep SE-0461's caller-isolated
 semantics. The `@concurrent` bodies never read `self.config`: the library
 target compiles in Swift 5 mode, so an off-actor read there would race
-`setToken`/`clearToken` without a compiler diagnostic. The delegate crosses the
+`setToken`/`clearToken` without a compiler diagnostic, which is why
+`scripts/check-transport-isolation.sh` enforces that shape in `make verify`. The delegate crosses the
 hop as a weak reference, so an in-flight request never extends its lifetime;
 swapping the delegate mid-request still delivers that request's failure to the
 delegate that was set when it started. Delegate callbacks arrive off the

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -25,7 +25,7 @@ for why and for the full strict-concurrency contract.
 - `make verify` runs `scripts/check-podspec-package.rb` through Bundler to ensure CocoaPods package pruning keeps `VERSION` and `podspec_helper.rb` without leaking a downloaded helper into later platform validation
 - `make verify` runs `./scripts/check-sendable-audit.sh` to keep the strict-concurrency `Sendable` audit list exhaustive
 - `make verify` runs `./scripts/check-transport-isolation.sh` so `PutioSDK.request` stays caller-isolated, `perform`/`execute` stay `@concurrent`, and no `@concurrent` transport body mentions `self` or reads bare `config`/`delegate`; parser fixtures live under `scripts/fixtures/transport-isolation/`
-- Device-code cancellation tests park the SDK through the internal `deviceCodePollObserver` and `deviceCodePollSleeper` seams instead of URLSession side effects, and one test cancels the production `Task.sleep` directly
+- Device-code cancellation tests park the SDK through the internal `deviceCodePollObserver`, `deviceCodePollSleeper`, and `deviceCodeSleepEntryObserver` seams instead of URLSession side effects; the production sleep primitive is cancelled directly and through the default polling loop
 - `make verify` runs `./scripts/check-platform-simulator-destination.sh` to cover the tvOS/watchOS destination parser with captured simulator listings
 - `make verify` runs package-level SwiftPM tests, including `PutioSDKTests` and `PutioSDKStrictConcurrencyTests` in one combined `swift test` invocation
 - `make verify` fails if source line coverage for `PutioSDK/Classes` drops below `90%`

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -25,7 +25,7 @@ for why and for the full strict-concurrency contract.
 - `make verify` runs `scripts/check-podspec-package.rb` through Bundler to ensure CocoaPods package pruning keeps `VERSION` and `podspec_helper.rb` without leaking a downloaded helper into later platform validation
 - `make verify` runs `./scripts/check-sendable-audit.sh` to keep the strict-concurrency `Sendable` audit list exhaustive
 - `make verify` runs `./scripts/check-transport-isolation.sh` so `PutioSDK.request` stays caller-isolated, `perform`/`execute` stay `@concurrent`, and no `@concurrent` transport body reads `self.` members or bare `config`/`delegate`; parser fixtures live under `scripts/fixtures/transport-isolation/`
-- Device-code cancellation tests park the SDK through the internal `deviceCodePollObserver` and `deviceCodePollSleeper` seams instead of timing or URLSession side effects
+- Device-code cancellation tests park the SDK through the internal `deviceCodePollObserver` and `deviceCodePollSleeper` seams instead of URLSession side effects, and one test cancels the production `Task.sleep` directly
 - `make verify` runs `./scripts/check-platform-simulator-destination.sh` to cover the tvOS/watchOS destination parser with captured simulator listings
 - `make verify` runs package-level SwiftPM tests, including `PutioSDKTests` and `PutioSDKStrictConcurrencyTests` in one combined `swift test` invocation
 - `make verify` fails if source line coverage for `PutioSDK/Classes` drops below `90%`

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -24,7 +24,8 @@ for why and for the full strict-concurrency contract.
 - `make verify` first runs `swift format lint --strict` with stock rules over the package, tests, example app, and scripts
 - `make verify` runs `scripts/check-podspec-package.rb` through Bundler to ensure CocoaPods package pruning keeps `VERSION` and `podspec_helper.rb` without leaking a downloaded helper into later platform validation
 - `make verify` runs `./scripts/check-sendable-audit.sh` to keep the strict-concurrency `Sendable` audit list exhaustive
-- `make verify` runs `./scripts/check-transport-isolation.sh` so `PutioSDK.request` stays caller-isolated and no `@concurrent` transport body reads `self.` members or bare `config`/`delegate`
+- `make verify` runs `./scripts/check-transport-isolation.sh` so `PutioSDK.request` stays caller-isolated, `perform`/`execute` stay `@concurrent`, and no `@concurrent` transport body reads `self.` members or bare `config`/`delegate`; parser fixtures live under `scripts/fixtures/transport-isolation/`
+- Device-code cancellation tests park the SDK through the internal `deviceCodePollObserver` seam instead of timing or URLSession side effects
 - `make verify` runs `./scripts/check-platform-simulator-destination.sh` to cover the tvOS/watchOS destination parser with captured simulator listings
 - `make verify` runs package-level SwiftPM tests, including `PutioSDKTests` and `PutioSDKStrictConcurrencyTests` in one combined `swift test` invocation
 - `make verify` fails if source line coverage for `PutioSDK/Classes` drops below `90%`

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -24,7 +24,7 @@ for why and for the full strict-concurrency contract.
 - `make verify` first runs `swift format lint --strict` with stock rules over the package, tests, example app, and scripts
 - `make verify` runs `scripts/check-podspec-package.rb` through Bundler to ensure CocoaPods package pruning keeps `VERSION` and `podspec_helper.rb` without leaking a downloaded helper into later platform validation
 - `make verify` runs `./scripts/check-sendable-audit.sh` to keep the strict-concurrency `Sendable` audit list exhaustive
-- `make verify` runs `./scripts/check-transport-isolation.sh` so `PutioSDK.request` stays caller-isolated, `perform`/`execute` stay `@concurrent`, and no `@concurrent` transport body reads `self.` members or bare `config`/`delegate`; parser fixtures live under `scripts/fixtures/transport-isolation/`
+- `make verify` runs `./scripts/check-transport-isolation.sh` so `PutioSDK.request` stays caller-isolated, `perform`/`execute` stay `@concurrent`, and no `@concurrent` transport body mentions `self` or reads bare `config`/`delegate`; parser fixtures live under `scripts/fixtures/transport-isolation/`
 - Device-code cancellation tests park the SDK through the internal `deviceCodePollObserver` and `deviceCodePollSleeper` seams instead of URLSession side effects, and one test cancels the production `Task.sleep` directly
 - `make verify` runs `./scripts/check-platform-simulator-destination.sh` to cover the tvOS/watchOS destination parser with captured simulator listings
 - `make verify` runs package-level SwiftPM tests, including `PutioSDKTests` and `PutioSDKStrictConcurrencyTests` in one combined `swift test` invocation

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -25,7 +25,7 @@ for why and for the full strict-concurrency contract.
 - `make verify` runs `scripts/check-podspec-package.rb` through Bundler to ensure CocoaPods package pruning keeps `VERSION` and `podspec_helper.rb` without leaking a downloaded helper into later platform validation
 - `make verify` runs `./scripts/check-sendable-audit.sh` to keep the strict-concurrency `Sendable` audit list exhaustive
 - `make verify` runs `./scripts/check-transport-isolation.sh` so `PutioSDK.request` stays caller-isolated, `perform`/`execute` stay `@concurrent`, and no `@concurrent` transport body reads `self.` members or bare `config`/`delegate`; parser fixtures live under `scripts/fixtures/transport-isolation/`
-- Device-code cancellation tests park the SDK through the internal `deviceCodePollObserver` seam instead of timing or URLSession side effects
+- Device-code cancellation tests park the SDK through the internal `deviceCodePollObserver` and `deviceCodePollSleeper` seams instead of timing or URLSession side effects
 - `make verify` runs `./scripts/check-platform-simulator-destination.sh` to cover the tvOS/watchOS destination parser with captured simulator listings
 - `make verify` runs package-level SwiftPM tests, including `PutioSDKTests` and `PutioSDKStrictConcurrencyTests` in one combined `swift test` invocation
 - `make verify` fails if source line coverage for `PutioSDK/Classes` drops below `90%`

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -25,7 +25,7 @@ for why and for the full strict-concurrency contract.
 - `make verify` runs `scripts/check-podspec-package.rb` through Bundler to ensure CocoaPods package pruning keeps `VERSION` and `podspec_helper.rb` without leaking a downloaded helper into later platform validation
 - `make verify` runs `./scripts/check-sendable-audit.sh` to keep the strict-concurrency `Sendable` audit list exhaustive
 - `make verify` runs `./scripts/check-transport-isolation.sh` so `PutioSDK.request` stays caller-isolated, `perform`/`execute` stay `@concurrent`, and no `@concurrent` transport body mentions `self` or reads bare `config`/`delegate`; parser fixtures live under `scripts/fixtures/transport-isolation/`
-- Device-code cancellation tests park the SDK through the internal `deviceCodePollObserver`, `deviceCodePollSleeper`, and `deviceCodeSleepEntryObserver` seams instead of URLSession side effects; the production sleep primitive is cancelled directly and through the default polling loop
+- Device-code cancellation tests park the SDK through the internal `deviceCodePollObserver` and `deviceCodePollClock` seams instead of URLSession side effects; a test clock observes sleep entry from inside the sleep, and the default `ContinuousClock` path is bounded on its cancellation response
 - `make verify` runs `./scripts/check-platform-simulator-destination.sh` to cover the tvOS/watchOS destination parser with captured simulator listings
 - `make verify` runs package-level SwiftPM tests, including `PutioSDKTests` and `PutioSDKStrictConcurrencyTests` in one combined `swift test` invocation
 - `make verify` fails if source line coverage for `PutioSDK/Classes` drops below `90%`

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -24,6 +24,7 @@ for why and for the full strict-concurrency contract.
 - `make verify` first runs `swift format lint --strict` with stock rules over the package, tests, example app, and scripts
 - `make verify` runs `scripts/check-podspec-package.rb` through Bundler to ensure CocoaPods package pruning keeps `VERSION` and `podspec_helper.rb` without leaking a downloaded helper into later platform validation
 - `make verify` runs `./scripts/check-sendable-audit.sh` to keep the strict-concurrency `Sendable` audit list exhaustive
+- `make verify` runs `./scripts/check-transport-isolation.sh` so `PutioSDK.request` stays caller-isolated and no `@concurrent` transport body reads `self.` members or bare `config`/`delegate`
 - `make verify` runs `./scripts/check-platform-simulator-destination.sh` to cover the tvOS/watchOS destination parser with captured simulator listings
 - `make verify` runs package-level SwiftPM tests, including `PutioSDKTests` and `PutioSDKStrictConcurrencyTests` in one combined `swift test` invocation
 - `make verify` fails if source line coverage for `PutioSDK/Classes` drops below `90%`

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -25,7 +25,7 @@ for why and for the full strict-concurrency contract.
 - `make verify` runs `scripts/check-podspec-package.rb` through Bundler to ensure CocoaPods package pruning keeps `VERSION` and `podspec_helper.rb` without leaking a downloaded helper into later platform validation
 - `make verify` runs `./scripts/check-sendable-audit.sh` to keep the strict-concurrency `Sendable` audit list exhaustive
 - `make verify` runs `./scripts/check-transport-isolation.sh` so `PutioSDK.request` stays caller-isolated, `perform`/`execute` stay `@concurrent`, and no `@concurrent` transport body mentions `self` or reads bare `config`/`delegate`; parser fixtures live under `scripts/fixtures/transport-isolation/`
-- Device-code cancellation tests park the SDK through the internal `deviceCodePollObserver` and `deviceCodePollClock` seams instead of URLSession side effects; a test clock observes sleep entry from inside the sleep, and the default `ContinuousClock` path is bounded on its cancellation response
+- Device-code cancellation tests park the SDK through the internal `deviceCodePollObserver` and `deviceCodePollClock` seams instead of URLSession side effects; a test clock observes sleep entry from inside the suspension for the deterministic mid-sleep proof, while the spy-clock and default `ContinuousClock` tests only bound the cancellation response
 - `make verify` runs `./scripts/check-platform-simulator-destination.sh` to cover the tvOS/watchOS destination parser with captured simulator listings
 - `make verify` runs package-level SwiftPM tests, including `PutioSDKTests` and `PutioSDKStrictConcurrencyTests` in one combined `swift test` invocation
 - `make verify` fails if source line coverage for `PutioSDK/Classes` drops below `90%`

--- a/scripts/check-transport-isolation.sh
+++ b/scripts/check-transport-isolation.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Guards the #52 contract in PutioSDK/Classes/PutioSDK.swift: `request` stays
+# caller-isolated and snapshots `config`/`delegate` on the caller's actor, and no
+# `@concurrent` body reads `self`, `config`, or `delegate`. The library target
+# compiles in Swift 5 mode, so the compiler would not catch an off-actor read.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+python3 scripts/lib/check-transport-isolation.py PutioSDK/Classes/PutioSDK.swift

--- a/scripts/check-transport-isolation.sh
+++ b/scripts/check-transport-isolation.sh
@@ -1,11 +1,39 @@
 #!/usr/bin/env bash
 # Guards the #52 contract in PutioSDK/Classes/PutioSDK.swift: `request` stays
-# caller-isolated and snapshots `config`/`delegate` on the caller's actor, and no
-# `@concurrent` body reads `self`, `config`, or `delegate`. The library target
-# compiles in Swift 5 mode, so the compiler would not catch an off-actor read.
+# caller-isolated and snapshots `config`/`delegate` on the caller's actor, while
+# `perform` and `execute` are `@concurrent` and never read `self.` members or bare
+# `config`/`delegate`. The library target compiles in Swift 5 mode, so the compiler
+# would not catch an off-actor read. Fixtures under scripts/fixtures/transport-isolation
+# keep the parser honest about comments, strings, and attribute layout.
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$repo_root"
 
-python3 scripts/lib/check-transport-isolation.py PutioSDK/Classes/PutioSDK.swift
+audit="python3 scripts/lib/check-transport-isolation.py"
+failures=0
+
+for fixture in scripts/fixtures/transport-isolation/pass/*.swift.txt; do
+  if $audit "$fixture" >/dev/null; then
+    echo "ok   fixture passes: ${fixture##*/}"
+  else
+    echo "FAIL fixture should pass: ${fixture##*/}"
+    failures=$((failures + 1))
+  fi
+done
+
+for fixture in scripts/fixtures/transport-isolation/fail/*.swift.txt; do
+  if $audit "$fixture" >/dev/null; then
+    echo "FAIL fixture should be rejected: ${fixture##*/}"
+    failures=$((failures + 1))
+  else
+    echo "ok   fixture rejected: ${fixture##*/}"
+  fi
+done
+
+if [ "${failures}" -ne 0 ]; then
+  echo "${failures} transport isolation fixture check(s) failed" >&2
+  exit 1
+fi
+
+$audit PutioSDK/Classes/PutioSDK.swift

--- a/scripts/fixtures/transport-isolation/fail/bare-delegate-read.swift.txt
+++ b/scripts/fixtures/transport-isolation/fail/bare-delegate-read.swift.txt
@@ -1,0 +1,10 @@
+public final class PutioSDK {
+  func request<T>(as type: T.Type) async throws -> sending T { try await perform(as: type) }
+  @concurrent
+  private func perform<T>(as type: T.Type) async throws -> sending T { try await execute() }
+  @concurrent
+  private func execute() async throws -> Data {
+    delegate?.onPutioSDKError(error: PutioSDKError())
+    return Data()
+  }
+}

--- a/scripts/fixtures/transport-isolation/fail/brace-in-string-hides-read.swift.txt
+++ b/scripts/fixtures/transport-isolation/fail/brace-in-string-hides-read.swift.txt
@@ -1,0 +1,11 @@
+public final class PutioSDK {
+  func request<T>(as type: T.Type) async throws -> sending T { try await perform(as: type) }
+  @concurrent
+  private func perform<T>(as type: T.Type) async throws -> sending T {
+    let sentinel = "}"
+    let token = config.token
+    return try await execute(sentinel, token)
+  }
+  @concurrent
+  private func execute(_ a: String, _ b: String) async throws -> Data { Data() }
+}

--- a/scripts/fixtures/transport-isolation/fail/custom-dot-operator-config-read.swift.txt
+++ b/scripts/fixtures/transport-isolation/fail/custom-dot-operator-config-read.swift.txt
@@ -1,0 +1,14 @@
+infix operator .+.
+public func .+. (lhs: Int, rhs: PutioSDKConfig) -> Int { lhs + rhs.clientID.count }
+
+public final class PutioSDK {
+  func request<T>(as type: T.Type) async throws -> sending T { try await perform(as: type) }
+  @concurrent
+  private func perform<T>(as type: T.Type) async throws -> sending T { try await execute() }
+  @concurrent
+  private func execute() async throws -> Data {
+    let total = 0 .+. config
+    _ = total
+    return Data()
+  }
+}

--- a/scripts/fixtures/transport-isolation/fail/dictionary-key-config-read.swift.txt
+++ b/scripts/fixtures/transport-isolation/fail/dictionary-key-config-read.swift.txt
@@ -1,0 +1,12 @@
+public final class PutioSDK {
+  func request<T>(as type: T.Type) async throws -> sending T { try await perform(as: type) }
+  @concurrent
+  private func perform<T>(as type: T.Type) async throws -> sending T { try await execute() }
+  @concurrent
+  private func execute() async throws -> Data {
+    let first = [config: 1]
+    let second = ["a": 0, delegate: 1]
+    _ = (first, second)
+    return Data()
+  }
+}

--- a/scripts/fixtures/transport-isolation/fail/escaped-self-identifier.swift.txt
+++ b/scripts/fixtures/transport-isolation/fail/escaped-self-identifier.swift.txt
@@ -1,0 +1,13 @@
+public final class PutioSDK {
+  func request<T>(as type: T.Type) async throws -> sending T { try await perform(as: type) }
+  @concurrent
+  private func perform<T>(as type: T.Type) async throws -> sending T {
+    `self`.clearToken()
+    return try await execute()
+  }
+  @concurrent
+  private func execute() async throws -> Data {
+    let token = `config`.token
+    return Data(token.utf8)
+  }
+}

--- a/scripts/fixtures/transport-isolation/fail/inline-attribute-on-request.swift.txt
+++ b/scripts/fixtures/transport-isolation/fail/inline-attribute-on-request.swift.txt
@@ -1,0 +1,7 @@
+public final class PutioSDK {
+  @concurrent func request<T>(as type: T.Type) async throws -> sending T { try await perform(as: type) }
+  @concurrent
+  private func perform<T>(as type: T.Type) async throws -> sending T { try await execute() }
+  @concurrent
+  private func execute() async throws -> Data { Data() }
+}

--- a/scripts/fixtures/transport-isolation/fail/interpolated-config-read.swift.txt
+++ b/scripts/fixtures/transport-isolation/fail/interpolated-config-read.swift.txt
@@ -1,0 +1,10 @@
+public final class PutioSDK {
+  func request<T>(as type: T.Type) async throws -> sending T { try await perform(as: type) }
+  @concurrent
+  private func perform<T>(as type: T.Type) async throws -> sending T {
+    let header = "token \(config.token)"
+    return try await execute(header)
+  }
+  @concurrent
+  private func execute(_ a: String) async throws -> Data { Data() }
+}

--- a/scripts/fixtures/transport-isolation/fail/interpolation-comment-hides-read.swift.txt
+++ b/scripts/fixtures/transport-isolation/fail/interpolation-comment-hides-read.swift.txt
@@ -1,0 +1,10 @@
+public final class PutioSDK {
+  func request<T>(as type: T.Type) async throws -> sending T { try await perform(as: type) }
+  @concurrent
+  private func perform<T>(as type: T.Type) async throws -> sending T {
+    let header = "token \(/* ) */ config.token)"
+    return try await execute(header)
+  }
+  @concurrent
+  private func execute(_ a: String) async throws -> Data { Data() }
+}

--- a/scripts/fixtures/transport-isolation/fail/optional-self-access.swift.txt
+++ b/scripts/fixtures/transport-isolation/fail/optional-self-access.swift.txt
@@ -1,0 +1,13 @@
+public final class PutioSDK {
+  func request<T>(as type: T.Type) async throws -> sending T { try await perform(as: type) }
+  @concurrent
+  private func perform<T>(as type: T.Type) async throws -> sending T {
+    let reset = { [weak self] in self?.clearToken() }
+    let forced: () -> Void = { [weak self] in self!.clearToken() }
+    reset()
+    forced()
+    return try await execute()
+  }
+  @concurrent
+  private func execute() async throws -> Data { Data() }
+}

--- a/scripts/fixtures/transport-isolation/fail/parenthesized-self-receiver.swift.txt
+++ b/scripts/fixtures/transport-isolation/fail/parenthesized-self-receiver.swift.txt
@@ -1,0 +1,10 @@
+public final class PutioSDK {
+  func request<T>(as type: T.Type) async throws -> sending T { try await perform(as: type) }
+  @concurrent
+  private func perform<T>(as type: T.Type) async throws -> sending T {
+    let snapshot = (self).config
+    return try await execute(snapshot)
+  }
+  @concurrent
+  private func execute(_ a: PutioSDKConfig) async throws -> Data { Data() }
+}

--- a/scripts/fixtures/transport-isolation/fail/perform-not-concurrent.swift.txt
+++ b/scripts/fixtures/transport-isolation/fail/perform-not-concurrent.swift.txt
@@ -1,0 +1,6 @@
+public final class PutioSDK {
+  func request<T>(as type: T.Type) async throws -> sending T { try await perform(as: type) }
+  private func perform<T>(as type: T.Type) async throws -> sending T { try await execute() }
+  @concurrent
+  private func execute() async throws -> Data { Data() }
+}

--- a/scripts/fixtures/transport-isolation/fail/range-operator-config-read.swift.txt
+++ b/scripts/fixtures/transport-isolation/fail/range-operator-config-read.swift.txt
@@ -1,0 +1,12 @@
+public final class PutioSDK {
+  func request<T>(as type: T.Type) async throws -> sending T { try await perform(as: type) }
+  @concurrent
+  private func perform<T>(as type: T.Type) async throws -> sending T { try await execute() }
+  @concurrent
+  private func execute() async throws -> Data {
+    let bounds = ...config.clientID.count
+    let open = 0..<delegate.debugDescription.count
+    _ = (bounds, open)
+    return Data()
+  }
+}

--- a/scripts/fixtures/transport-isolation/fail/raw-interpolated-self-read.swift.txt
+++ b/scripts/fixtures/transport-isolation/fail/raw-interpolated-self-read.swift.txt
@@ -1,0 +1,10 @@
+public final class PutioSDK {
+  func request<T>(as type: T.Type) async throws -> sending T { try await perform(as: type) }
+  @concurrent
+  private func perform<T>(as type: T.Type) async throws -> sending T {
+    let header = #"token \#(self.config.token) "quoted""#
+    return try await execute(header)
+  }
+  @concurrent
+  private func execute(_ a: String) async throws -> Data { Data() }
+}

--- a/scripts/fixtures/transport-isolation/fail/read-on-brace-line.swift.txt
+++ b/scripts/fixtures/transport-isolation/fail/read-on-brace-line.swift.txt
@@ -1,0 +1,7 @@
+public final class PutioSDK {
+  func request<T>(as type: T.Type) async throws -> sending T { try await perform(as: type) }
+  @concurrent
+  private func perform<T>(as type: T.Type) async throws -> sending T { self.clearToken(); return try await execute() }
+  @concurrent
+  private func execute() async throws -> Data { Data() }
+}

--- a/scripts/fixtures/transport-isolation/fail/regex-brace-hides-read.swift.txt
+++ b/scripts/fixtures/transport-isolation/fail/regex-brace-hides-read.swift.txt
@@ -1,0 +1,11 @@
+public final class PutioSDK {
+  func request<T>(as type: T.Type) async throws -> sending T { try await perform(as: type) }
+  @concurrent
+  private func perform<T>(as type: T.Type) async throws -> sending T {
+    let closer = #/}/#
+    let token = config.token
+    return try await execute(closer, token)
+  }
+  @concurrent
+  private func execute(_ a: Regex<Substring>, _ b: String) async throws -> Data { Data() }
+}

--- a/scripts/fixtures/transport-isolation/fail/regex-escaped-delimiter-hides-read.swift.txt
+++ b/scripts/fixtures/transport-isolation/fail/regex-escaped-delimiter-hides-read.swift.txt
@@ -1,0 +1,11 @@
+public final class PutioSDK {
+  func request<T>(as type: T.Type) async throws -> sending T { try await perform(as: type) }
+  @concurrent
+  private func perform<T>(as type: T.Type) async throws -> sending T {
+    let pattern = #/foo\/#}bar/#
+    let token = config.token
+    return try await execute(pattern, token)
+  }
+  @concurrent
+  private func execute(_ a: Regex<Substring>, _ b: String) async throws -> Data { Data() }
+}

--- a/scripts/fixtures/transport-isolation/fail/returned-dictionary-key-config-read.swift.txt
+++ b/scripts/fixtures/transport-isolation/fail/returned-dictionary-key-config-read.swift.txt
@@ -1,0 +1,10 @@
+public final class PutioSDK {
+  func request<T>(as type: T.Type) async throws -> sending T { try await perform(as: type) }
+  @concurrent
+  private func perform<T>(as type: T.Type) async throws -> sending T { try await execute() }
+  @concurrent
+  private func execute() async throws -> Data {
+    if Bool.random() { return Data(String(describing: [config: 1]).utf8) }
+    return try [delegate: 1].isEmpty ? Data() : Data()
+  }
+}

--- a/scripts/fixtures/transport-isolation/fail/spaced-self-member.swift.txt
+++ b/scripts/fixtures/transport-isolation/fail/spaced-self-member.swift.txt
@@ -1,0 +1,10 @@
+public final class PutioSDK {
+  func request<T>(as type: T.Type) async throws -> sending T { try await perform(as: type) }
+  @concurrent
+  private func perform<T>(as type: T.Type) async throws -> sending T {
+    self /* hop */ .clearToken()
+    return try await execute()
+  }
+  @concurrent
+  private func execute() async throws -> Data { Data() }
+}

--- a/scripts/fixtures/transport-isolation/fail/ternary-config-read.swift.txt
+++ b/scripts/fixtures/transport-isolation/fail/ternary-config-read.swift.txt
@@ -1,0 +1,10 @@
+public final class PutioSDK {
+  func request<T>(as type: T.Type) async throws -> sending T { try await perform(as: type) }
+  @concurrent
+  private func perform<T>(as type: T.Type) async throws -> sending T {
+    let snapshot = Bool.random() ? config : PutioSDKConfig(clientID: "x")
+    return try await execute(snapshot)
+  }
+  @concurrent
+  private func execute(_ a: PutioSDKConfig) async throws -> Data { Data() }
+}

--- a/scripts/fixtures/transport-isolation/fail/unannotated-execute-overload.swift.txt
+++ b/scripts/fixtures/transport-isolation/fail/unannotated-execute-overload.swift.txt
@@ -1,0 +1,8 @@
+public final class PutioSDK {
+  func request<T>(as type: T.Type) async throws -> sending T { try await perform(as: type) }
+  @concurrent
+  private func perform<T>(as type: T.Type) async throws -> sending T { try await execute(retries: 1) }
+  @concurrent
+  private func execute() async throws -> Data { Data() }
+  private func execute(retries: Int) async throws -> Data { try await execute() }
+}

--- a/scripts/fixtures/transport-isolation/fail/unicode-dot-operator-config-read.swift.txt
+++ b/scripts/fixtures/transport-isolation/fail/unicode-dot-operator-config-read.swift.txt
@@ -1,0 +1,14 @@
+infix operator .⊕.
+public func .⊕. (lhs: Int, rhs: PutioSDKConfig) -> Int { lhs + rhs.clientID.count }
+
+public final class PutioSDK {
+  func request<T>(as type: T.Type) async throws -> sending T { try await perform(as: type) }
+  @concurrent
+  private func perform<T>(as type: T.Type) async throws -> sending T { try await execute() }
+  @concurrent
+  private func execute() async throws -> Data {
+    let total = 0 .⊕. config
+    _ = total
+    return Data()
+  }
+}

--- a/scripts/fixtures/transport-isolation/pass/comments-and-strings.swift.txt
+++ b/scripts/fixtures/transport-isolation/pass/comments-and-strings.swift.txt
@@ -19,6 +19,9 @@ public final class PutioSDK {
     let data = try await execute(requestConfig: requestConfig, delegateReference: delegateReference)
     _ = String(decoding: data, as: UTF8.self)
     _ = PutioSDKErrorRequestInformation(config: requestConfig)
+    _ = "\(/* ) */ requestConfig.baseURL) \(String(describing: requestConfig.baseURL, config: 1))"
+    _ = PutioSDKErrorRequestInformation(
+      config: requestConfig)
     _ = (sentinel, block, nested)
     return try JSONDecoder().decode(type, from: data)
   }

--- a/scripts/fixtures/transport-isolation/pass/comments-and-strings.swift.txt
+++ b/scripts/fixtures/transport-isolation/pass/comments-and-strings.swift.txt
@@ -18,6 +18,7 @@ public final class PutioSDK {
       """
     let data = try await execute(requestConfig: requestConfig, delegateReference: delegateReference)
     _ = String(decoding: data, as: UTF8.self)
+    _ = (UTF8.self, Data.self)
     _ = PutioSDKErrorRequestInformation(config: requestConfig)
     _ = "\(/* ) */ requestConfig.baseURL) \(String(describing: requestConfig.baseURL, config: 1))"
     _ = PutioSDKErrorRequestInformation(

--- a/scripts/fixtures/transport-isolation/pass/comments-and-strings.swift.txt
+++ b/scripts/fixtures/transport-isolation/pass/comments-and-strings.swift.txt
@@ -24,7 +24,7 @@ public final class PutioSDK {
       .baseURL
     _ = delegateReference?.describe()
     let optionalSnapshot: PutioSDKConfig? = requestConfig
-    _ = (optionalSnapshot?.config, optionalSnapshot!.delegate, optionalSnapshot ?. config)
+    _ = (optionalSnapshot?.config, optionalSnapshot!.delegate)
     _ = PutioSDKErrorRequestInformation(config: requestConfig)
     _ = "\(/* ) */ requestConfig.baseURL) \(String(describing: requestConfig.baseURL, config: 1))"
     _ = PutioSDKErrorRequestInformation(

--- a/scripts/fixtures/transport-isolation/pass/comments-and-strings.swift.txt
+++ b/scripts/fixtures/transport-isolation/pass/comments-and-strings.swift.txt
@@ -30,7 +30,9 @@ public final class PutioSDK {
     let commented = requestConfig./* hop */baseURL
     let chained = delegateReference
       .describe()
-    _ = (sentinel, block, nested, opener, multiline, spaced, commented, chained)
+    let escapedSlash = #/a\/#{ self.config }/#
+    let `escapedLocal` = requestConfig.baseURL
+    _ = (sentinel, block, nested, opener, multiline, spaced, commented, chained, escapedSlash, `escapedLocal`)
     return try JSONDecoder().decode(type, from: data)
   }
 

--- a/scripts/fixtures/transport-isolation/pass/comments-and-strings.swift.txt
+++ b/scripts/fixtures/transport-isolation/pass/comments-and-strings.swift.txt
@@ -25,7 +25,7 @@ public final class PutioSDK {
     _ = delegateReference?.describe()
     let optionalSnapshot: PutioSDKConfig? = requestConfig
     _ = (optionalSnapshot?.config, optionalSnapshot!.delegate)
-    _ = [requestConfig].map(\\.config)
+    _ = [requestConfig].map(\.config)
     _ = requestConfig[config: 1]
     _ = requestConfig.update(config:delegate:)
     _ = PutioSDKErrorRequestInformation(config: requestConfig)

--- a/scripts/fixtures/transport-isolation/pass/comments-and-strings.swift.txt
+++ b/scripts/fixtures/transport-isolation/pass/comments-and-strings.swift.txt
@@ -18,7 +18,7 @@ public final class PutioSDK {
       """
     let data = try await execute(requestConfig: requestConfig, delegateReference: delegateReference)
     _ = String(decoding: data, as: UTF8.self)
-    _ = (UTF8.self, Data.self)
+    _ = (UTF8.self, Data.self, UTF8 . self, Data./* metatype */self)
     _ = PutioSDKErrorRequestInformation(config: requestConfig)
     _ = "\(/* ) */ requestConfig.baseURL) \(String(describing: requestConfig.baseURL, config: 1))"
     _ = PutioSDKErrorRequestInformation(

--- a/scripts/fixtures/transport-isolation/pass/comments-and-strings.swift.txt
+++ b/scripts/fixtures/transport-isolation/pass/comments-and-strings.swift.txt
@@ -25,6 +25,9 @@ public final class PutioSDK {
     _ = delegateReference?.describe()
     let optionalSnapshot: PutioSDKConfig? = requestConfig
     _ = (optionalSnapshot?.config, optionalSnapshot!.delegate)
+    _ = [requestConfig].map(\\.config)
+    _ = requestConfig[config: 1]
+    _ = requestConfig.update(config:delegate:)
     _ = PutioSDKErrorRequestInformation(config: requestConfig)
     _ = "\(/* ) */ requestConfig.baseURL) \(String(describing: requestConfig.baseURL, config: 1))"
     _ = PutioSDKErrorRequestInformation(

--- a/scripts/fixtures/transport-isolation/pass/comments-and-strings.swift.txt
+++ b/scripts/fixtures/transport-isolation/pass/comments-and-strings.swift.txt
@@ -23,6 +23,8 @@ public final class PutioSDK {
     _ = requestConfig
       .baseURL
     _ = delegateReference?.describe()
+    let optionalSnapshot: PutioSDKConfig? = requestConfig
+    _ = (optionalSnapshot?.config, optionalSnapshot!.delegate, optionalSnapshot ?. config)
     _ = PutioSDKErrorRequestInformation(config: requestConfig)
     _ = "\(/* ) */ requestConfig.baseURL) \(String(describing: requestConfig.baseURL, config: 1))"
     _ = PutioSDKErrorRequestInformation(

--- a/scripts/fixtures/transport-isolation/pass/comments-and-strings.swift.txt
+++ b/scripts/fixtures/transport-isolation/pass/comments-and-strings.swift.txt
@@ -26,7 +26,11 @@ public final class PutioSDK {
     let multiline = ##/
       { self.config } "delegate"
       /##
-    _ = (sentinel, block, nested, opener, multiline)
+    let spaced = requestConfig . baseURL
+    let commented = requestConfig./* hop */baseURL
+    let chained = delegateReference
+      .describe()
+    _ = (sentinel, block, nested, opener, multiline, spaced, commented, chained)
     return try JSONDecoder().decode(type, from: data)
   }
 

--- a/scripts/fixtures/transport-isolation/pass/comments-and-strings.swift.txt
+++ b/scripts/fixtures/transport-isolation/pass/comments-and-strings.swift.txt
@@ -12,13 +12,14 @@ public final class PutioSDK {
   private func perform<T>(config requestConfig: PutioSDKConfig, delegateReference: PutioSDKDelegateReference, as type: T.Type) async throws -> sending T {
     // line comment: self.config delegate }
     let sentinel = "}" + "\(requestConfig.baseURL) delegate \"self.config\"" + #"raw "self.delegate" }"#
+    let nested = "outer \(String(describing: "inner \(requestConfig.baseURL) }")) tail"
     let block = """
       self.config delegate }
       """
     let data = try await execute(requestConfig: requestConfig, delegateReference: delegateReference)
     _ = String(decoding: data, as: UTF8.self)
     _ = PutioSDKErrorRequestInformation(config: requestConfig)
-    _ = (sentinel, block)
+    _ = (sentinel, block, nested)
     return try JSONDecoder().decode(type, from: data)
   }
 

--- a/scripts/fixtures/transport-isolation/pass/comments-and-strings.swift.txt
+++ b/scripts/fixtures/transport-isolation/pass/comments-and-strings.swift.txt
@@ -22,7 +22,11 @@ public final class PutioSDK {
     _ = "\(/* ) */ requestConfig.baseURL) \(String(describing: requestConfig.baseURL, config: 1))"
     _ = PutioSDKErrorRequestInformation(
       config: requestConfig)
-    _ = (sentinel, block, nested)
+    let opener = #/{ config delegate self./#
+    let multiline = ##/
+      { self.config } "delegate"
+      /##
+    _ = (sentinel, block, nested, opener, multiline)
     return try JSONDecoder().decode(type, from: data)
   }
 

--- a/scripts/fixtures/transport-isolation/pass/comments-and-strings.swift.txt
+++ b/scripts/fixtures/transport-isolation/pass/comments-and-strings.swift.txt
@@ -28,6 +28,10 @@ public final class PutioSDK {
     _ = [requestConfig].map(\.config)
     _ = requestConfig[config: 1]
     _ = requestConfig.update(config:delegate:)
+    let field: PutioField = .config
+    let other: PutioField = (.delegate)
+    describe(.config, then: .delegate)
+    _ = (field, other)
     _ = PutioSDKErrorRequestInformation(config: requestConfig)
     _ = "\(/* ) */ requestConfig.baseURL) \(String(describing: requestConfig.baseURL, config: 1))"
     _ = PutioSDKErrorRequestInformation(

--- a/scripts/fixtures/transport-isolation/pass/comments-and-strings.swift.txt
+++ b/scripts/fixtures/transport-isolation/pass/comments-and-strings.swift.txt
@@ -1,0 +1,29 @@
+public final class PutioSDK {
+  public var config: PutioSDKConfig
+  public weak var delegate: PutioSDKDelegate?
+
+  func request<T>(_ url: String, as type: T.Type) async throws -> sending T {
+    let snapshot = config
+    return try await perform(config: snapshot, delegateReference: PutioSDKDelegateReference(delegate), as: type)
+  }
+
+  /* block comment mentioning self.config and delegate { */
+  @concurrent
+  private func perform<T>(config requestConfig: PutioSDKConfig, delegateReference: PutioSDKDelegateReference, as type: T.Type) async throws -> sending T {
+    // line comment: self.config delegate }
+    let sentinel = "}" + "\(requestConfig.baseURL) delegate \"self.config\"" + #"raw "self.delegate" }"#
+    let block = """
+      self.config delegate }
+      """
+    let data = try await execute(requestConfig: requestConfig, delegateReference: delegateReference)
+    _ = String(decoding: data, as: UTF8.self)
+    _ = PutioSDKErrorRequestInformation(config: requestConfig)
+    _ = (sentinel, block)
+    return try JSONDecoder().decode(type, from: data)
+  }
+
+  @concurrent private func execute(requestConfig: PutioSDKConfig, delegateReference: PutioSDKDelegateReference) async throws -> Data {
+    delegateReference.notify(PutioSDKError())
+    return Data()
+  }
+}

--- a/scripts/fixtures/transport-isolation/pass/comments-and-strings.swift.txt
+++ b/scripts/fixtures/transport-isolation/pass/comments-and-strings.swift.txt
@@ -19,6 +19,7 @@ public final class PutioSDK {
     let data = try await execute(requestConfig: requestConfig, delegateReference: delegateReference)
     _ = String(decoding: data, as: UTF8.self)
     _ = (UTF8.self, Data.self, UTF8 . self, Data./* metatype */self)
+    _ = (...requestConfig.baseURL.count, 0..<requestConfig.baseURL.count)
     _ = PutioSDKErrorRequestInformation(config: requestConfig)
     _ = "\(/* ) */ requestConfig.baseURL) \(String(describing: requestConfig.baseURL, config: 1))"
     _ = PutioSDKErrorRequestInformation(

--- a/scripts/fixtures/transport-isolation/pass/comments-and-strings.swift.txt
+++ b/scripts/fixtures/transport-isolation/pass/comments-and-strings.swift.txt
@@ -20,6 +20,9 @@ public final class PutioSDK {
     _ = String(decoding: data, as: UTF8.self)
     _ = (UTF8.self, Data.self, UTF8 . self, Data./* metatype */self)
     _ = (...requestConfig.baseURL.count, 0..<requestConfig.baseURL.count)
+    _ = requestConfig
+      .baseURL
+    _ = delegateReference?.describe()
     _ = PutioSDKErrorRequestInformation(config: requestConfig)
     _ = "\(/* ) */ requestConfig.baseURL) \(String(describing: requestConfig.baseURL, config: 1))"
     _ = PutioSDKErrorRequestInformation(

--- a/scripts/lib/check-transport-isolation.py
+++ b/scripts/lib/check-transport-isolation.py
@@ -1,0 +1,58 @@
+import pathlib
+import re
+import sys
+
+path = pathlib.Path(sys.argv[1])
+lines = path.read_text().splitlines()
+# `self.` member access, or a bare `config`/`delegate` identifier that is not an
+# argument label (`config:`), a member (`.config`), or a metatype (`Foo.self`).
+forbidden = re.compile(r"(?<![.\w])self\.|(?<![.\w])(config|delegate)\b(?!\s*:)")
+failures = []
+concurrent_bodies = 0
+
+
+def strip_comment(line):
+    return line.split("//", 1)[0]
+
+
+index = 0
+while index < len(lines):
+    if lines[index].strip() != "@concurrent":
+        index += 1
+        continue
+
+    header_start = index + 1
+    cursor = header_start
+    while "{" not in lines[cursor]:
+        cursor += 1
+    header = " ".join(l.strip() for l in lines[header_start : cursor + 1])
+    if re.search(r"\bfunc request\b", header):
+        failures.append(f"line {header_start + 1}: `request` must stay caller-isolated, not @concurrent")
+
+    depth = 0
+    body_start = cursor
+    while True:
+        code = strip_comment(lines[cursor])
+        depth += code.count("{") - code.count("}")
+        if cursor > body_start:
+            for match in forbidden.finditer(code):
+                failures.append(
+                    f"line {cursor + 1}: `{match.group(0).rstrip('.')}` read inside @concurrent body: {lines[cursor].strip()}"
+                )
+        if depth == 0:
+            break
+        cursor += 1
+    concurrent_bodies += 1
+    index = cursor + 1
+
+if not any(re.search(r"\bfunc request<", l) for l in lines):
+    failures.append("could not find `func request<` declaration")
+
+print(f"Transport isolation audit: {concurrent_bodies} @concurrent body(ies) checked in {path}.")
+if concurrent_bodies == 0:
+    failures.append("expected at least one @concurrent transport body")
+
+if failures:
+    for failure in failures:
+        print(f"  - {failure}")
+    sys.exit(1)

--- a/scripts/lib/check-transport-isolation.py
+++ b/scripts/lib/check-transport-isolation.py
@@ -10,10 +10,12 @@ Rules (see docs/ARCHITECTURE.md, "Internal transport isolation"):
     `delegate`. Only argument-label positions (`f(config: x)`, `f(config y: x)`)
     are exempt; ternary operands and other expressions are not.
 
-Comments and string literal text (including multi-line and raw strings) are
-blanked before parsing so they cannot hide or fake a match. Interpolation
-expressions are executable Swift and are lexed with the same rules, including
-comments and nested strings inside them.
+Comments, string literal text (including multi-line and raw strings), and
+extended regex literals (`#/.../#`) are blanked before parsing so they cannot
+hide or fake a match. Interpolation expressions are executable Swift and are
+lexed with the same rules, including comments and nested strings inside them.
+Bare `/regex/` literals are not handled: the library target compiles in Swift 5
+mode without `BareSlashRegexLiterals`, so they cannot appear in this file.
 """
 
 import re
@@ -22,7 +24,7 @@ from pathlib import Path
 
 REQUIRED_CONCURRENT = {"perform", "execute"}
 FORBIDDEN_CONCURRENT = {"request"}
-SELF_MEMBER = re.compile(r"(?<![.\w])self\s*\.")
+SELF_MEMBER = re.compile(r"(?<![.\w])self\s*[?!]?\s*\.")
 STATE_IDENT = re.compile(r"(?<![.\w])(config|delegate)\b")
 LABEL_AFTER = re.compile(r"\s*(?:[A-Za-z_]\w*\s*)?:(?!:)")
 FUNC_DECL = re.compile(r"\bfunc\s+([A-Za-z_]\w*)")
@@ -64,6 +66,9 @@ def lex(source, i, out, until_close_paren=False):
             if k < n and source[k] == '"':
                 i = scan_string(source, k, hashes, out)
                 continue
+            if hashes and k < n and source[k] == "/":
+                i = scan_regex(source, k, hashes, out)
+                continue
         ch = source[i]
         out.append(ch)
         i += 1
@@ -102,6 +107,20 @@ def scan_string(source, start, hashes, out):
         out.append(blank(source[j]))
         j += 1
     return n
+
+
+def scan_regex(source, start, hashes, out):
+    """Blank an extended regex literal opening at `start` (the slash) and return the
+    index past its `/` + hashes terminator."""
+    n = len(source)
+    closing = "/" + "#" * hashes
+    out.append("/")
+    j = start + 1
+    while j < n and not source.startswith(closing, j):
+        out.append(blank(source[j]))
+        j += 1
+    out.append("/")
+    return min(n, j + len(closing))
 
 
 def strip_comments_and_strings(source):

--- a/scripts/lib/check-transport-isolation.py
+++ b/scripts/lib/check-transport-isolation.py
@@ -148,8 +148,10 @@ def line_of(text, offset):
 
 
 def is_argument_label(text, match):
+    """Argument labels in calls, subscripts, and compound function references such
+    as `f(config: x)`, `s[config: key]`, or `f(config:delegate:)`."""
     before = text[: match.start()].rstrip()
-    if not before or before[-1] not in "(,":
+    if not before or before[-1] not in "(,[:":
         return False
     return LABEL_AFTER.match(text, match.end()) is not None
 
@@ -168,7 +170,8 @@ def is_member_access(text, match):
     receiver = before[:-1].rstrip()
     if receiver.endswith(("?", "!")):
         receiver = receiver[:-1].rstrip()
-    return bool(receiver) and (receiver[-1].isalnum() or receiver[-1] in "_)]`\"")
+    # A key path with an inferred root (`\.config`) names a member, not SDK state.
+    return bool(receiver) and (receiver[-1].isalnum() or receiver[-1] in "_)]`\"\\")
 
 
 def forbidden_reads(body):

--- a/scripts/lib/check-transport-isolation.py
+++ b/scripts/lib/check-transport-isolation.py
@@ -9,8 +9,9 @@ Rules (see docs/ARCHITECTURE.md, "Internal transport isolation"):
   * No `@concurrent` body may use `self.` member access or a bare `config` or
     `delegate` identifier. Argument labels (`config:`) are allowed.
 
-Comments and string literals (including interpolation, multi-line, and raw
-strings) are blanked before parsing so they cannot hide or fake a match.
+Comments and string literal text (including multi-line and raw strings) are
+blanked before parsing so they cannot hide or fake a match. Interpolation
+expressions inside strings are executable Swift and are kept for auditing.
 """
 
 import re
@@ -19,7 +20,7 @@ from pathlib import Path
 
 REQUIRED_CONCURRENT = {"perform", "execute"}
 FORBIDDEN_CONCURRENT = {"request"}
-FORBIDDEN_READ = re.compile(r"(?<![.\w])self\.|(?<![.\w])(?:config|delegate)\b(?!\s*:)")
+FORBIDDEN_READ = re.compile(r"(?<![.\w])self\s*\.|(?<![.\w])(?:config|delegate)\b(?!\s*:)")
 FUNC_DECL = re.compile(r"\bfunc\s+([A-Za-z_]\w*)")
 
 
@@ -27,30 +28,38 @@ def blank(text):
     return "".join("\n" if ch == "\n" else " " for ch in text)
 
 
-def skip_string(source, start, hashes):
-    """Return the index just past the string literal opening at `start` (a quote)."""
+def scan_string(source, start, hashes, out):
+    """Blank the literal text of the string opening at `start` (a quote) into `out`,
+    keeping interpolation expressions verbatim, and return the index past it."""
     n = len(source)
     multiline = source.startswith('"""', start)
     closing = ('"""' if multiline else '"') + "#" * hashes
     escape = "\\" + "#" * hashes
     j = start + (3 if multiline else 1)
+    out.append('"')
     while j < n:
         if source.startswith(escape, j):
             after = j + len(escape)
             if source.startswith("(", after):
                 depth, k = 1, after + 1
+                out.append(" (")
                 while k < n and depth:
-                    if source[k] == '"':
-                        k = skip_string(source, k, 0)
+                    ch = source[k]
+                    if ch == '"':
+                        k = scan_string(source, k, 0, out)
                         continue
-                    depth += (source[k] == "(") - (source[k] == ")")
+                    depth += (ch == "(") - (ch == ")")
+                    out.append(ch)
                     k += 1
                 j = k
             else:
+                out.append("\n" if source[after : after + 1] == "\n" else " ")
                 j = after + 1
             continue
         if source.startswith(closing, j):
+            out.append('"')
             return j + len(closing)
+        out.append("\n" if source[j] == "\n" else " ")
         j += 1
     return n
 
@@ -81,9 +90,7 @@ def strip_comments_and_strings(source):
             while k < n and source[k] == "#":
                 k, hashes = k + 1, hashes + 1
             if k < n and source[k] == '"':
-                j = skip_string(source, k, hashes)
-                out.append('""' + "".join(ch for ch in source[i:j] if ch == "\n"))
-                i = j
+                i = scan_string(source, k, hashes, out)
                 continue
         out.append(source[i])
         i += 1
@@ -130,7 +137,7 @@ def audit(path):
         for match in FORBIDDEN_READ.finditer(body):
             line = line_of(text, k + match.start())
             failures.append(
-                f"line {line}: `{match.group(0).rstrip('.')}` read inside @concurrent `{name}`: {lines[line - 1].strip()}"
+                f"line {line}: `{match.group(0).rstrip(' .')}` read inside @concurrent `{name}`: {lines[line - 1].strip()}"
             )
 
     for name in sorted(FORBIDDEN_CONCURRENT & concurrent.keys()):

--- a/scripts/lib/check-transport-isolation.py
+++ b/scripts/lib/check-transport-isolation.py
@@ -6,8 +6,8 @@ Rules (see docs/ARCHITECTURE.md, "Internal transport isolation"):
   * `request` must not be `@concurrent`; it snapshots `config`/`delegate` on the
     caller's actor.
   * `perform` and `execute` must both be `@concurrent`.
-  * No `@concurrent` body may use `self.` member access or read `config` or
-    `delegate`. Only argument-label positions (`f(config: x)`, `f(config y: x)`)
+  * No `@concurrent` body may mention `self` (member access, chaining, or a
+    parenthesised receiver) or read `config` or `delegate`. Only argument-label positions (`f(config: x)`, `f(config y: x)`)
     are exempt; ternary operands and other expressions are not.
 
 Comments, string literal text (including multi-line and raw strings), and
@@ -26,7 +26,10 @@ from pathlib import Path
 
 REQUIRED_CONCURRENT = {"perform", "execute"}
 FORBIDDEN_CONCURRENT = {"request"}
-SELF_MEMBER = re.compile(r"(?<![.\w])self\s*[?!]?\s*\.")
+# Any use of the instance itself (member access, optional or forced chaining,
+# parenthesised receiver, passing it along) is off-actor state access. `.self`
+# metatype references are preceded by a dot and stay allowed.
+SELF_TOKEN = re.compile(r"(?<![.\w])self\b")
 STATE_IDENT = re.compile(r"(?<!\w)(config|delegate)\b")
 LABEL_AFTER = re.compile(r"\s*(?:[A-Za-z_]\w*\s*)?:(?!:)")
 FUNC_DECL = re.compile(r"\bfunc\s+([A-Za-z_]\w*)")
@@ -156,7 +159,7 @@ def is_member_access(text, match):
 
 
 def forbidden_reads(body):
-    for match in SELF_MEMBER.finditer(body):
+    for match in SELF_TOKEN.finditer(body):
         yield match.start(), "self"
     for match in STATE_IDENT.finditer(body):
         if is_member_access(body, match) or is_argument_label(body, match):

--- a/scripts/lib/check-transport-isolation.py
+++ b/scripts/lib/check-transport-isolation.py
@@ -167,7 +167,7 @@ def is_member_access(text, match):
         return False
     receiver = before[:-1].rstrip()
     if receiver.endswith(("?", "!")):
-        receiver = receiver[:-1]
+        receiver = receiver[:-1].rstrip()
     return bool(receiver) and (receiver[-1].isalnum() or receiver[-1] in "_)]`\"")
 
 

--- a/scripts/lib/check-transport-isolation.py
+++ b/scripts/lib/check-transport-isolation.py
@@ -147,13 +147,45 @@ def line_of(text, offset):
     return text.count("\n", 0, offset) + 1
 
 
+def has_receiver(text, end):
+    """True when `text[:end]` ends in something that can receive a call or
+    subscript: an identifier or literal character, a closing bracket, a backtick,
+    or a `?`/`!` postfix on one of those."""
+    receiver = text[:end].rstrip()
+    if receiver.endswith(("?", "!")):
+        receiver = receiver[:-1].rstrip()
+    return bool(receiver) and (receiver[-1].isalnum() or receiver[-1] in "_)]`\"")
+
+
+def enclosing_open_bracket(text, position):
+    """Index of the unmatched `(` or `[` enclosing `position`, or None."""
+    depth = 0
+    for index in range(position - 1, -1, -1):
+        ch = text[index]
+        if ch in ")]":
+            depth += 1
+        elif ch in "([":
+            if depth == 0:
+                return index
+            depth -= 1
+    return None
+
+
 def is_argument_label(text, match):
     """Argument labels in calls, subscripts, and compound function references such
-    as `f(config: x)`, `s[config: key]`, or `f(config:delegate:)`."""
+    as `f(config: x)`, `s[config: key]`, or `f(config:delegate:)`. Dictionary
+    literal keys look the same but have no receiver before their `[`."""
     before = text[: match.start()].rstrip()
     if not before or before[-1] not in "(,[:":
         return False
-    return LABEL_AFTER.match(text, match.end()) is not None
+    if LABEL_AFTER.match(text, match.end()) is None:
+        return False
+    opener = enclosing_open_bracket(text, match.start())
+    if opener is None:
+        return False
+    if text[opener] == "(":
+        return True
+    return has_receiver(text, opener)
 
 
 def is_member_access(text, match):
@@ -167,11 +199,10 @@ def is_member_access(text, match):
     before = text[: match.start()].rstrip()
     if not before.endswith("."):
         return False
-    receiver = before[:-1].rstrip()
-    if receiver.endswith(("?", "!")):
-        receiver = receiver[:-1].rstrip()
     # A key path with an inferred root (`\.config`) names a member, not SDK state.
-    return bool(receiver) and (receiver[-1].isalnum() or receiver[-1] in "_)]`\"\\")
+    if before[:-1].rstrip().endswith("\\"):
+        return True
+    return has_receiver(before, len(before) - 1)
 
 
 def forbidden_reads(body):

--- a/scripts/lib/check-transport-isolation.py
+++ b/scripts/lib/check-transport-isolation.py
@@ -1,58 +1,151 @@
-import pathlib
+"""Structural audit for the transport isolation contract in PutioSDK.swift.
+
+Usage: check-transport-isolation.py <swift-file>
+
+Rules (see docs/ARCHITECTURE.md, "Internal transport isolation"):
+  * `request` must not be `@concurrent`; it snapshots `config`/`delegate` on the
+    caller's actor.
+  * `perform` and `execute` must both be `@concurrent`.
+  * No `@concurrent` body may use `self.` member access or a bare `config` or
+    `delegate` identifier. Argument labels (`config:`) are allowed.
+
+Comments and string literals (including interpolation, multi-line, and raw
+strings) are blanked before parsing so they cannot hide or fake a match.
+"""
+
 import re
 import sys
+from pathlib import Path
 
-path = pathlib.Path(sys.argv[1])
-lines = path.read_text().splitlines()
-# `self.` member access, or a bare `config`/`delegate` identifier that is not an
-# argument label (`config:`), a member (`.config`), or a metatype (`Foo.self`).
-forbidden = re.compile(r"(?<![.\w])self\.|(?<![.\w])(config|delegate)\b(?!\s*:)")
-failures = []
-concurrent_bodies = 0
+REQUIRED_CONCURRENT = {"perform", "execute"}
+FORBIDDEN_CONCURRENT = {"request"}
+FORBIDDEN_READ = re.compile(r"(?<![.\w])self\.|(?<![.\w])(?:config|delegate)\b(?!\s*:)")
+FUNC_DECL = re.compile(r"\bfunc\s+([A-Za-z_]\w*)")
 
 
-def strip_comment(line):
-    return line.split("//", 1)[0]
+def blank(text):
+    return "".join("\n" if ch == "\n" else " " for ch in text)
 
 
-index = 0
-while index < len(lines):
-    if lines[index].strip() != "@concurrent":
-        index += 1
-        continue
+def skip_string(source, start, hashes):
+    """Return the index just past the string literal opening at `start` (a quote)."""
+    n = len(source)
+    multiline = source.startswith('"""', start)
+    closing = ('"""' if multiline else '"') + "#" * hashes
+    escape = "\\" + "#" * hashes
+    j = start + (3 if multiline else 1)
+    while j < n:
+        if source.startswith(escape, j):
+            after = j + len(escape)
+            if source.startswith("(", after):
+                depth, k = 1, after + 1
+                while k < n and depth:
+                    if source[k] == '"':
+                        k = skip_string(source, k, 0)
+                        continue
+                    depth += (source[k] == "(") - (source[k] == ")")
+                    k += 1
+                j = k
+            else:
+                j = after + 1
+            continue
+        if source.startswith(closing, j):
+            return j + len(closing)
+        j += 1
+    return n
 
-    header_start = index + 1
-    cursor = header_start
-    while "{" not in lines[cursor]:
-        cursor += 1
-    header = " ".join(l.strip() for l in lines[header_start : cursor + 1])
-    if re.search(r"\bfunc request\b", header):
-        failures.append(f"line {header_start + 1}: `request` must stay caller-isolated, not @concurrent")
 
-    depth = 0
-    body_start = cursor
-    while True:
-        code = strip_comment(lines[cursor])
-        depth += code.count("{") - code.count("}")
-        if cursor > body_start:
-            for match in forbidden.finditer(code):
-                failures.append(
-                    f"line {cursor + 1}: `{match.group(0).rstrip('.')}` read inside @concurrent body: {lines[cursor].strip()}"
-                )
-        if depth == 0:
-            break
-        cursor += 1
-    concurrent_bodies += 1
-    index = cursor + 1
+def strip_comments_and_strings(source):
+    out, i, n = [], 0, len(source)
+    while i < n:
+        if source.startswith("//", i):
+            j = source.find("\n", i)
+            j = n if j == -1 else j
+            out.append(blank(source[i:j]))
+            i = j
+            continue
+        if source.startswith("/*", i):
+            depth, j = 1, i + 2
+            while j < n and depth:
+                if source.startswith("/*", j):
+                    depth, j = depth + 1, j + 2
+                elif source.startswith("*/", j):
+                    depth, j = depth - 1, j + 2
+                else:
+                    j += 1
+            out.append(blank(source[i:j]))
+            i = j
+            continue
+        if source[i] in '#"':
+            k, hashes = i, 0
+            while k < n and source[k] == "#":
+                k, hashes = k + 1, hashes + 1
+            if k < n and source[k] == '"':
+                j = skip_string(source, k, hashes)
+                out.append('""' + "".join(ch for ch in source[i:j] if ch == "\n"))
+                i = j
+                continue
+        out.append(source[i])
+        i += 1
+    return "".join(out)
 
-if not any(re.search(r"\bfunc request<", l) for l in lines):
-    failures.append("could not find `func request<` declaration")
 
-print(f"Transport isolation audit: {concurrent_bodies} @concurrent body(ies) checked in {path}.")
-if concurrent_bodies == 0:
-    failures.append("expected at least one @concurrent transport body")
+def line_of(text, offset):
+    return text.count("\n", 0, offset) + 1
 
-if failures:
+
+def audit(path):
+    original = path.read_text()
+    text = strip_comments_and_strings(original)
+    lines = original.splitlines()
+    failures = []
+    concurrent = {}
+
+    for attr in re.finditer(r"@concurrent\b", text):
+        decl = FUNC_DECL.search(text, attr.end())
+        between = text[attr.end() : decl.start()] if decl else ""
+        if not decl or re.search(r"[{};]", between):
+            failures.append(f"line {line_of(text, attr.start())}: @concurrent is not attached to a func")
+            continue
+        name = decl.group(1)
+        if name in concurrent:
+            failures.append(f"line {line_of(text, decl.start())}: duplicate @concurrent func `{name}`")
+        concurrent[name] = decl.start()
+
+        depth, k = 0, decl.end()
+        while k < len(text) and not (text[k] == "{" and depth == 0):
+            depth += (text[k] == "(") - (text[k] == ")")
+            k += 1
+        if k >= len(text):
+            failures.append(f"line {line_of(text, decl.start())}: could not find body of `{name}`")
+            continue
+        braces, end = 1, k + 1
+        while end < len(text) and braces:
+            braces += (text[end] == "{") - (text[end] == "}")
+            end += 1
+        if braces:
+            failures.append(f"line {line_of(text, decl.start())}: unbalanced body for `{name}`")
+            continue
+        body = text[k:end]
+        for match in FORBIDDEN_READ.finditer(body):
+            line = line_of(text, k + match.start())
+            failures.append(
+                f"line {line}: `{match.group(0).rstrip('.')}` read inside @concurrent `{name}`: {lines[line - 1].strip()}"
+            )
+
+    for name in sorted(FORBIDDEN_CONCURRENT & concurrent.keys()):
+        failures.append(f"line {line_of(text, concurrent[name])}: `{name}` must stay caller-isolated, not @concurrent")
+    for name in sorted(REQUIRED_CONCURRENT - concurrent.keys()):
+        failures.append(f"`{name}` must be @concurrent")
+    for name in sorted(REQUIRED_CONCURRENT | FORBIDDEN_CONCURRENT):
+        if not re.search(r"\bfunc\s+" + name + r"\b", text):
+            failures.append(f"could not find `func {name}` declaration")
+
+    print(f"Transport isolation audit: {len(concurrent)} @concurrent body(ies) checked in {path}.")
     for failure in failures:
         print(f"  - {failure}")
-    sys.exit(1)
+    return not failures
+
+
+if __name__ == "__main__":
+    sys.exit(0 if audit(Path(sys.argv[1])) else 1)

--- a/scripts/lib/check-transport-isolation.py
+++ b/scripts/lib/check-transport-isolation.py
@@ -11,7 +11,9 @@ Rules (see docs/ARCHITECTURE.md, "Internal transport isolation"):
     are exempt; ternary operands and other expressions are not.
 
 Comments, string literal text (including multi-line and raw strings), and
-extended regex literals (`#/.../#`) are blanked before parsing so they cannot
+extended regex literals (`#/.../#`, honouring backslash escapes) are blanked
+before parsing; backtick identifier escapes are dropped so an escaped self or
+config audits as the plain identifier. All of that happens before parsing so they cannot
 hide or fake a match. Interpolation expressions are executable Swift and are
 lexed with the same rules, including comments and nested strings inside them.
 Bare `/regex/` literals are not handled: the library target compiles in Swift 5
@@ -70,7 +72,9 @@ def lex(source, i, out, until_close_paren=False):
                 i = scan_regex(source, k, hashes, out)
                 continue
         ch = source[i]
-        out.append(ch)
+        # Swift allows escaping identifiers in backticks (`self`, `config`); the escaped
+        # form names the same entity, so drop the backticks and audit the identifier.
+        out.append(" " if ch == "`" else ch)
         i += 1
         if until_close_paren:
             if ch == "(":
@@ -117,6 +121,12 @@ def scan_regex(source, start, hashes, out):
     out.append("/")
     j = start + 1
     while j < n and not source.startswith(closing, j):
+        if source[j] == "\\" and j + 1 < n:
+            # An escaped character (including `\/`) never terminates the literal.
+            out.append(blank(source[j]))
+            out.append(blank(source[j + 1]))
+            j += 2
+            continue
         out.append(blank(source[j]))
         j += 1
     out.append("/")

--- a/scripts/lib/check-transport-isolation.py
+++ b/scripts/lib/check-transport-isolation.py
@@ -154,11 +154,18 @@ def is_argument_label(text, match):
     return LABEL_AFTER.match(text, match.end()) is not None
 
 
+# Swift operator characters. A member-access dot is a lone `.` not adjacent to any
+# other operator character; `...`, `..<`, and custom dot-operators such as `.+.`
+# start a fresh expression instead.
+OPERATOR_CHARS = set("./=-+!*%<>&|^~?")
+
+
 def is_member_access(text, match):
-    """True when the token is preceded by a single member-access dot. The range
-    operators `...` and `..<` also end in a dot but start a fresh expression."""
+    """True when the token is preceded by a standalone member-access dot."""
     before = text[: match.start()].rstrip()
-    return before.endswith(".") and not before.endswith("..")
+    if not before.endswith("."):
+        return False
+    return len(before) < 2 or before[-2] not in OPERATOR_CHARS
 
 
 def forbidden_reads(body):

--- a/scripts/lib/check-transport-isolation.py
+++ b/scripts/lib/check-transport-isolation.py
@@ -155,8 +155,10 @@ def is_argument_label(text, match):
 
 
 def is_member_access(text, match):
+    """True when the token is preceded by a single member-access dot. The range
+    operators `...` and `..<` also end in a dot but start a fresh expression."""
     before = text[: match.start()].rstrip()
-    return before.endswith(".")
+    return before.endswith(".") and not before.endswith("..")
 
 
 def forbidden_reads(body):

--- a/scripts/lib/check-transport-isolation.py
+++ b/scripts/lib/check-transport-isolation.py
@@ -147,14 +147,30 @@ def line_of(text, offset):
     return text.count("\n", 0, offset) + 1
 
 
+# Keywords that can precede an expression but never act as a call, subscript, or
+# member-access receiver.
+NON_RECEIVER_KEYWORDS = {
+    "as", "await", "case", "default", "else", "for", "guard", "if", "in", "inout",
+    "is", "let", "repeat", "return", "some", "any", "switch", "then", "throw",
+    "throws", "try", "var", "where", "while", "yield",
+}
+TRAILING_WORD = re.compile(r"([A-Za-z_]\w*)$")
+
+
 def has_receiver(text, end):
-    """True when `text[:end]` ends in something that can receive a call or
-    subscript: an identifier or literal character, a closing bracket, a backtick,
-    or a `?`/`!` postfix on one of those."""
+    """True when `text[:end]` ends in something that can receive a call, subscript,
+    or member access: an identifier or literal character, a closing bracket, a
+    backtick, or a `?`/`!` postfix on one of those. Statement keywords such as
+    `return` are not receivers."""
     receiver = text[:end].rstrip()
     if receiver.endswith(("?", "!")):
         receiver = receiver[:-1].rstrip()
-    return bool(receiver) and (receiver[-1].isalnum() or receiver[-1] in "_)]`\"")
+    if not receiver:
+        return False
+    word = TRAILING_WORD.search(receiver)
+    if word and word.group(1) in NON_RECEIVER_KEYWORDS:
+        return False
+    return receiver[-1].isalnum() or receiver[-1] in "_)]`\""
 
 
 def enclosing_open_bracket(text, position):
@@ -201,6 +217,13 @@ def is_member_access(text, match):
         return False
     # A key path with an inferred root (`\.config`) names a member, not SDK state.
     if before[:-1].rstrip().endswith("\\"):
+        return True
+    # An implicit member expression (`= .config`, `f(.delegate)`) resolves against
+    # the contextual type, never against the SDK instance. The dot must directly
+    # follow whitespace or an opening token; anything else (`...`, `.+.`) is an
+    # operator.
+    previous = before[-2] if len(before) >= 2 else None
+    if previous is None or previous.isspace() or previous in "=(,:[{":
         return True
     return has_receiver(before, len(before) - 1)
 

--- a/scripts/lib/check-transport-isolation.py
+++ b/scripts/lib/check-transport-isolation.py
@@ -6,12 +6,14 @@ Rules (see docs/ARCHITECTURE.md, "Internal transport isolation"):
   * `request` must not be `@concurrent`; it snapshots `config`/`delegate` on the
     caller's actor.
   * `perform` and `execute` must both be `@concurrent`.
-  * No `@concurrent` body may use `self.` member access or a bare `config` or
-    `delegate` identifier. Argument labels (`config:`) are allowed.
+  * No `@concurrent` body may use `self.` member access or read `config` or
+    `delegate`. Only argument-label positions (`f(config: x)`, `f(config y: x)`)
+    are exempt; ternary operands and other expressions are not.
 
 Comments and string literal text (including multi-line and raw strings) are
 blanked before parsing so they cannot hide or fake a match. Interpolation
-expressions inside strings are executable Swift and are kept for auditing.
+expressions are executable Swift and are lexed with the same rules, including
+comments and nested strings inside them.
 """
 
 import re
@@ -20,17 +22,64 @@ from pathlib import Path
 
 REQUIRED_CONCURRENT = {"perform", "execute"}
 FORBIDDEN_CONCURRENT = {"request"}
-FORBIDDEN_READ = re.compile(r"(?<![.\w])self\s*\.|(?<![.\w])(?:config|delegate)\b(?!\s*:)")
+SELF_MEMBER = re.compile(r"(?<![.\w])self\s*\.")
+STATE_IDENT = re.compile(r"(?<![.\w])(config|delegate)\b")
+LABEL_AFTER = re.compile(r"\s*(?:[A-Za-z_]\w*\s*)?:(?!:)")
 FUNC_DECL = re.compile(r"\bfunc\s+([A-Za-z_]\w*)")
 
 
-def blank(text):
-    return "".join("\n" if ch == "\n" else " " for ch in text)
+def blank(ch):
+    return "\n" if ch == "\n" else " "
+
+
+def lex(source, i, out, until_close_paren=False):
+    """Copy code from `source[i:]` into `out` with comments and string text blanked.
+
+    With `until_close_paren`, stop after the `)` that closes paren depth 0 and
+    return the index past it; otherwise consume to the end.
+    """
+    n, depth = len(source), 0
+    while i < n:
+        if source.startswith("//", i):
+            while i < n and source[i] != "\n":
+                out.append(" ")
+                i += 1
+            continue
+        if source.startswith("/*", i):
+            nested, j = 1, i + 2
+            while j < n and nested:
+                if source.startswith("/*", j):
+                    nested, j = nested + 1, j + 2
+                elif source.startswith("*/", j):
+                    nested, j = nested - 1, j + 2
+                else:
+                    j += 1
+            out.extend(blank(ch) for ch in source[i:j])
+            i = j
+            continue
+        if source[i] in '#"':
+            k, hashes = i, 0
+            while k < n and source[k] == "#":
+                k, hashes = k + 1, hashes + 1
+            if k < n and source[k] == '"':
+                i = scan_string(source, k, hashes, out)
+                continue
+        ch = source[i]
+        out.append(ch)
+        i += 1
+        if until_close_paren:
+            if ch == "(":
+                depth += 1
+            elif ch == ")":
+                if depth == 0:
+                    return i
+                depth -= 1
+    return n
 
 
 def scan_string(source, start, hashes, out):
-    """Blank the literal text of the string opening at `start` (a quote) into `out`,
-    keeping interpolation expressions verbatim, and return the index past it."""
+    """Blank the literal text of the string opening at `start` (a quote), lexing
+    interpolation expressions as code, and return the index past the string."""
     n = len(source)
     multiline = source.startswith('"""', start)
     closing = ('"""' if multiline else '"') + "#" * hashes
@@ -41,64 +90,43 @@ def scan_string(source, start, hashes, out):
         if source.startswith(escape, j):
             after = j + len(escape)
             if source.startswith("(", after):
-                depth, k = 1, after + 1
                 out.append(" (")
-                while k < n and depth:
-                    ch = source[k]
-                    if ch == '"':
-                        k = scan_string(source, k, 0, out)
-                        continue
-                    depth += (ch == "(") - (ch == ")")
-                    out.append(ch)
-                    k += 1
-                j = k
+                j = lex(source, after + 1, out, until_close_paren=True)
             else:
-                out.append("\n" if source[after : after + 1] == "\n" else " ")
+                out.append(blank(source[after]) if after < n else " ")
                 j = after + 1
             continue
         if source.startswith(closing, j):
             out.append('"')
             return j + len(closing)
-        out.append("\n" if source[j] == "\n" else " ")
+        out.append(blank(source[j]))
         j += 1
     return n
 
 
 def strip_comments_and_strings(source):
-    out, i, n = [], 0, len(source)
-    while i < n:
-        if source.startswith("//", i):
-            j = source.find("\n", i)
-            j = n if j == -1 else j
-            out.append(blank(source[i:j]))
-            i = j
-            continue
-        if source.startswith("/*", i):
-            depth, j = 1, i + 2
-            while j < n and depth:
-                if source.startswith("/*", j):
-                    depth, j = depth + 1, j + 2
-                elif source.startswith("*/", j):
-                    depth, j = depth - 1, j + 2
-                else:
-                    j += 1
-            out.append(blank(source[i:j]))
-            i = j
-            continue
-        if source[i] in '#"':
-            k, hashes = i, 0
-            while k < n and source[k] == "#":
-                k, hashes = k + 1, hashes + 1
-            if k < n and source[k] == '"':
-                i = scan_string(source, k, hashes, out)
-                continue
-        out.append(source[i])
-        i += 1
+    out = []
+    lex(source, 0, out)
     return "".join(out)
 
 
 def line_of(text, offset):
     return text.count("\n", 0, offset) + 1
+
+
+def is_argument_label(text, match):
+    before = text[: match.start()].rstrip()
+    if not before or before[-1] not in "(,":
+        return False
+    return LABEL_AFTER.match(text, match.end()) is not None
+
+
+def forbidden_reads(body):
+    for match in SELF_MEMBER.finditer(body):
+        yield match.start(), "self"
+    for match in STATE_IDENT.finditer(body):
+        if not is_argument_label(body, match):
+            yield match.start(), match.group(1)
 
 
 def audit(path):
@@ -134,10 +162,10 @@ def audit(path):
             failures.append(f"line {line_of(text, decl.start())}: unbalanced body for `{name}`")
             continue
         body = text[k:end]
-        for match in FORBIDDEN_READ.finditer(body):
-            line = line_of(text, k + match.start())
+        for offset, what in sorted(forbidden_reads(body)):
+            line = line_of(text, k + offset)
             failures.append(
-                f"line {line}: `{match.group(0).rstrip(' .')}` read inside @concurrent `{name}`: {lines[line - 1].strip()}"
+                f"line {line}: `{what}` read inside @concurrent `{name}`: {lines[line - 1].strip()}"
             )
 
     for name in sorted(FORBIDDEN_CONCURRENT & concurrent.keys()):

--- a/scripts/lib/check-transport-isolation.py
+++ b/scripts/lib/check-transport-isolation.py
@@ -161,11 +161,17 @@ OPERATOR_CHARS = set("./=-+!*%<>&|^~?")
 
 
 def is_member_access(text, match):
-    """True when the token is preceded by a standalone member-access dot."""
+    """True when the token is preceded by a member-access dot: a standalone `.`, or
+    the optional-chaining `?.` / forced-unwrap `!.` forms."""
     before = text[: match.start()].rstrip()
     if not before.endswith("."):
         return False
-    return len(before) < 2 or before[-2] not in OPERATOR_CHARS
+    if len(before) < 2:
+        return True
+    previous = before[-2]
+    if previous in "?!":
+        return len(before) < 3 or before[-3] not in OPERATOR_CHARS
+    return previous not in OPERATOR_CHARS
 
 
 def forbidden_reads(body):

--- a/scripts/lib/check-transport-isolation.py
+++ b/scripts/lib/check-transport-isolation.py
@@ -25,7 +25,7 @@ from pathlib import Path
 REQUIRED_CONCURRENT = {"perform", "execute"}
 FORBIDDEN_CONCURRENT = {"request"}
 SELF_MEMBER = re.compile(r"(?<![.\w])self\s*[?!]?\s*\.")
-STATE_IDENT = re.compile(r"(?<![.\w])(config|delegate)\b")
+STATE_IDENT = re.compile(r"(?<!\w)(config|delegate)\b")
 LABEL_AFTER = re.compile(r"\s*(?:[A-Za-z_]\w*\s*)?:(?!:)")
 FUNC_DECL = re.compile(r"\bfunc\s+([A-Za-z_]\w*)")
 
@@ -140,12 +140,18 @@ def is_argument_label(text, match):
     return LABEL_AFTER.match(text, match.end()) is not None
 
 
+def is_member_access(text, match):
+    before = text[: match.start()].rstrip()
+    return before.endswith(".")
+
+
 def forbidden_reads(body):
     for match in SELF_MEMBER.finditer(body):
         yield match.start(), "self"
     for match in STATE_IDENT.finditer(body):
-        if not is_argument_label(body, match):
-            yield match.start(), match.group(1)
+        if is_member_access(body, match) or is_argument_label(body, match):
+            continue
+        yield match.start(), match.group(1)
 
 
 def audit(path):
@@ -162,9 +168,7 @@ def audit(path):
             failures.append(f"line {line_of(text, attr.start())}: @concurrent is not attached to a func")
             continue
         name = decl.group(1)
-        if name in concurrent:
-            failures.append(f"line {line_of(text, decl.start())}: duplicate @concurrent func `{name}`")
-        concurrent[name] = decl.start()
+        concurrent[decl.start()] = name
 
         depth, k = 0, decl.end()
         while k < len(text) and not (text[k] == "{" and depth == 0):
@@ -187,13 +191,22 @@ def audit(path):
                 f"line {line}: `{what}` read inside @concurrent `{name}`: {lines[line - 1].strip()}"
             )
 
-    for name in sorted(FORBIDDEN_CONCURRENT & concurrent.keys()):
-        failures.append(f"line {line_of(text, concurrent[name])}: `{name}` must stay caller-isolated, not @concurrent")
-    for name in sorted(REQUIRED_CONCURRENT - concurrent.keys()):
-        failures.append(f"`{name}` must be @concurrent")
+    # Every declaration (overloads included) of each named helper must carry the
+    # expected annotation state, so an unannotated overload cannot slip past.
+    annotated_offsets = set(concurrent.keys())
     for name in sorted(REQUIRED_CONCURRENT | FORBIDDEN_CONCURRENT):
-        if not re.search(r"\bfunc\s+" + name + r"\b", text):
+        declarations = [m for m in FUNC_DECL.finditer(text) if m.group(1) == name]
+        if not declarations:
             failures.append(f"could not find `func {name}` declaration")
+            continue
+        for decl in declarations:
+            annotated = decl.start() in annotated_offsets
+            if name in REQUIRED_CONCURRENT and not annotated:
+                failures.append(f"line {line_of(text, decl.start())}: `{name}` must be @concurrent")
+            if name in FORBIDDEN_CONCURRENT and annotated:
+                failures.append(
+                    f"line {line_of(text, decl.start())}: `{name}` must stay caller-isolated, not @concurrent"
+                )
 
     print(f"Transport isolation audit: {len(concurrent)} @concurrent body(ies) checked in {path}.")
     for failure in failures:

--- a/scripts/lib/check-transport-isolation.py
+++ b/scripts/lib/check-transport-isolation.py
@@ -28,8 +28,9 @@ REQUIRED_CONCURRENT = {"perform", "execute"}
 FORBIDDEN_CONCURRENT = {"request"}
 # Any use of the instance itself (member access, optional or forced chaining,
 # parenthesised receiver, passing it along) is off-actor state access. `.self`
-# metatype references are preceded by a dot and stay allowed.
-SELF_TOKEN = re.compile(r"(?<![.\w])self\b")
+# metatype references are preceded by a dot (possibly with whitespace or a
+# stripped comment in between) and stay allowed.
+SELF_TOKEN = re.compile(r"(?<!\w)self\b")
 STATE_IDENT = re.compile(r"(?<!\w)(config|delegate)\b")
 LABEL_AFTER = re.compile(r"\s*(?:[A-Za-z_]\w*\s*)?:(?!:)")
 FUNC_DECL = re.compile(r"\bfunc\s+([A-Za-z_]\w*)")
@@ -160,7 +161,8 @@ def is_member_access(text, match):
 
 def forbidden_reads(body):
     for match in SELF_TOKEN.finditer(body):
-        yield match.start(), "self"
+        if not is_member_access(body, match):
+            yield match.start(), "self"
     for match in STATE_IDENT.finditer(body):
         if is_member_access(body, match) or is_argument_label(body, match):
             continue

--- a/scripts/lib/check-transport-isolation.py
+++ b/scripts/lib/check-transport-isolation.py
@@ -154,24 +154,21 @@ def is_argument_label(text, match):
     return LABEL_AFTER.match(text, match.end()) is not None
 
 
-# Swift operator characters. A member-access dot is a lone `.` not adjacent to any
-# other operator character; `...`, `..<`, and custom dot-operators such as `.+.`
-# start a fresh expression instead.
-OPERATOR_CHARS = set("./=-+!*%<>&|^~?")
-
-
 def is_member_access(text, match):
-    """True when the token is preceded by a member-access dot: a standalone `.`, or
-    the optional-chaining `?.` / forced-unwrap `!.` forms."""
+    """True when the token is preceded by a member-access dot.
+
+    Instead of enumerating operator characters (Swift allows a wide Unicode set
+    in custom operators), require the dot to follow something that can be a
+    member-access receiver: an identifier or literal character, a closing
+    bracket, a backtick, or `?`/`!` postfix on such a receiver.
+    """
     before = text[: match.start()].rstrip()
     if not before.endswith("."):
         return False
-    if len(before) < 2:
-        return True
-    previous = before[-2]
-    if previous in "?!":
-        return len(before) < 3 or before[-3] not in OPERATOR_CHARS
-    return previous not in OPERATOR_CHARS
+    receiver = before[:-1].rstrip()
+    if receiver.endswith(("?", "!")):
+        receiver = receiver[:-1]
+    return bool(receiver) and (receiver[-1].isalnum() or receiver[-1] in "_)]`\"")
 
 
 def forbidden_reads(body):


### PR DESCRIPTION
## Problem

Independent review (slopguard, Codex) of the v3.6.0 range raised two test gaps:

1. The #52 fix had no executable guard. The library compiles in Swift 5 mode, so moving the config snapshot back into a `@concurrent` body would compile and silently reintroduce the race. The delegate-off-actor contract in ARCHITECTURE.md was also unasserted.
2. The device-code cancellation tests cancelled from inside the URLProtocol handler, which cancels the in-flight URLSession task. They passed through the `URLError.cancelled` normalization and never reached the post-poll cancellation check with a result in hand. Removing that check left them green.

## Solution

- `scripts/check-transport-isolation.sh` runs in `make verify`: `request` must not be `@concurrent`, and no `@concurrent` body in `PutioSDK.swift` may use `self.` members or bare `config`/`delegate`. The concurrent helpers now take `delegateReference` so the bare identifier is forbidden. Verified the audit fails when a bare `delegate` read is reintroduced.
- Delegate callback tests run from `@MainActor` and assert the callback is not on the main thread, both for the shared transport and for the device-code failure path.
- Cancellation tests use a `TaskCompletionObserver` on the session (the async `data(for:)` API only forwards `didFinishCollecting metrics` to the session delegate) plus an actor host. The sleep case cancels after the poll has completed and bounds elapsed time. The post-poll case holds the owning actor so the `.authorized` resumption stays queued, cancels, then releases. Dropping `try Task.checkCancellation()` after the poll makes that test fail with `authorized(token: <redacted>)`.

## Proof

- `make verify` green locally, coverage 91.62%.
- Auth and transport suites run 5x consecutively with 0 failures.
- Mutation checks: audit catches a bare `delegate` read; post-poll test catches the removed cancellation check.